### PR TITLE
merge: feature/2-feat-implement-probability-calculation-engine (#5)

### DIFF
--- a/WorldCupSimulatorApp/WCS.Api/Program.cs
+++ b/WorldCupSimulatorApp/WCS.Api/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using WCS.Domain.Entities;
 using WCS.Infrastructure.Persistence;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -11,6 +12,9 @@ builder.Services.AddDbContext<EFCoreDbContext>(options =>
 {
     options.UseNpgsql(builder.Configuration["ConnectionString:EFCoreDBConnection"]);
 });
+
+builder.Services.Configure<RatingWeightsOptions>(
+    builder.Configuration.GetSection("RatingWeights"));
 
 var app = builder.Build();
 

--- a/WorldCupSimulatorApp/WCS.Api/Program.cs
+++ b/WorldCupSimulatorApp/WCS.Api/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using WCS.Application.Services.Probabilities;
 using WCS.Application.Services.Ratings;
+using WCS.Application.Services.Simulators;
 using WCS.Domain.Entities;
 using WCS.Infrastructure.Persistence;
 
@@ -20,6 +21,7 @@ builder.Services.Configure<RatingWeightsOptions>(
 
 builder.Services.AddScoped<IRatingService, RatingService>();
 builder.Services.AddScoped<IMatchProbabilityService, MatchProbabilityService>();
+builder.Services.AddScoped<ISimulationService, SimulationService>();
 
 var app = builder.Build();
 

--- a/WorldCupSimulatorApp/WCS.Api/Program.cs
+++ b/WorldCupSimulatorApp/WCS.Api/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using WCS.Application.Services.Probabilities;
 using WCS.Application.Services.Ratings;
 using WCS.Domain.Entities;
 using WCS.Infrastructure.Persistence;
@@ -18,6 +19,7 @@ builder.Services.Configure<RatingWeightsOptions>(
     builder.Configuration.GetSection("RatingWeights"));
 
 builder.Services.AddScoped<IRatingService, RatingService>();
+builder.Services.AddScoped<IMatchProbabilityService, MatchProbabilityService>();
 
 var app = builder.Build();
 

--- a/WorldCupSimulatorApp/WCS.Api/Program.cs
+++ b/WorldCupSimulatorApp/WCS.Api/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using WCS.Application.Services.Ratings;
 using WCS.Domain.Entities;
 using WCS.Infrastructure.Persistence;
 
@@ -15,6 +16,8 @@ builder.Services.AddDbContext<EFCoreDbContext>(options =>
 
 builder.Services.Configure<RatingWeightsOptions>(
     builder.Configuration.GetSection("RatingWeights"));
+
+builder.Services.AddScoped<IRatingService, RatingService>();
 
 var app = builder.Build();
 

--- a/WorldCupSimulatorApp/WCS.Api/appsettings.json
+++ b/WorldCupSimulatorApp/WCS.Api/appsettings.json
@@ -9,5 +9,21 @@
 
   "ConnectionString": {
     "EFCoreDBConnection": ""
+  },
+
+  "RatingWeights": {
+    "Competition": {
+      "Friendly": 0.85,
+      "Qualifier": 1.10,
+      "ContinentalCup": 1.20,
+      "WorldCup": 1.40
+    },
+    "Stage": {
+      "Group": 1.00,
+      "RoundOf16": 1.10,
+      "QuarterFinal": 1.15,
+      "SemiFinal": 1.25,
+      "Final": 1.30
+    }
   }
 }

--- a/WorldCupSimulatorApp/WCS.Application/Class1.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace WCS.Application
-{
-    public class Class1
-    {
-
-    }
-}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/MatchesDTO/AdaptativeMatchResultDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/MatchesDTO/AdaptativeMatchResultDTO.cs
@@ -1,0 +1,21 @@
+﻿using WCS.Domain.Enums;
+
+namespace WCS.Application.DTO.MatchesDTO
+{
+    public class AdaptativeMatchResultDTO
+    {
+        public string TeamA { get; set; } = string.Empty;
+        public string TeamB { get; set; } = string.Empty;
+        public int GoalsA { get; set; }
+        public int GoalsB { get; set; }
+        public MatchOutcome Winner { get; set; }
+        public int? WinnerID { get; set; }
+        public double OutcomeProbability { get; set; }
+        public double ScoreProbability { get; set; }
+        public bool DecidedByPenalties { get; set; } = false;
+        public double WinnerAccumulatedScores { get; set; }
+        public double WinnerAccumulatedWeights { get; set; }
+        public double WinnerAccumulatedPenalties { get; set; }
+        public int WinnerAccumulatedCount { get; set; }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/MatchesDTO/AdaptativeSimulationMatchDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/MatchesDTO/AdaptativeSimulationMatchDTO.cs
@@ -1,0 +1,18 @@
+﻿namespace WCS.Application.DTO.MatchesDTO
+{
+    public class AdaptativeSimulationMatchDTO
+    {
+        public int TeamAID { get; set; }
+        public string TeamA { get; set; } = string.Empty;
+        public double AAccumulatedScores { get; set; }
+        public double AAccumulatedWeights { get; set; }
+        public double AAccumulatedPenalties { get; set; }
+        public int AAccumulatedCount { get; set; }
+        public int TeamBID { get; set; }
+        public string TeamB { get; set; } = string.Empty;
+        public double BAccumulatedScores { get; set; }
+        public double BAccumulatedWeights { get; set; }
+        public double BAccumulatedPenalties { get; set; }
+        public int BAccumulatedCount { get; set; }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/MatchesDTO/KnockoutWinnerDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/MatchesDTO/KnockoutWinnerDTO.cs
@@ -1,0 +1,11 @@
+﻿using WCS.Domain.Enums;
+
+namespace WCS.Application.DTO.MatchesDTO
+{
+    public class KnockoutWinnerDTO
+    {
+        public MatchOutcome MatchOutcome { get; set; }
+        public double AProbability { get; set; }
+        public double BProbability { get; set; }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/MatchesDTO/MatchResultDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/MatchesDTO/MatchResultDTO.cs
@@ -1,0 +1,17 @@
+﻿using WCS.Domain.Enums;
+
+namespace WCS.Application.DTO.MatchesDTO
+{
+    public class MatchResultDTO
+    {
+        public string TeamA { get; set; } = string.Empty;
+        public string TeamB { get; set; } = string.Empty;
+        public int GoalsA { get; set; }
+        public int GoalsB { get; set; }
+        public MatchOutcome Winner { get; set; }
+        public int? WinnerID { get; set; }
+        public double OutcomeProbability { get; set; }
+        public double ScoreProbability { get; set; }
+        public bool DecidedByPenalties { get; set; } = false;
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/MatchesDTO/SimpleMatchResultDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/MatchesDTO/SimpleMatchResultDTO.cs
@@ -1,0 +1,13 @@
+﻿using WCS.Domain.Enums;
+
+namespace WCS.Application.DTO.MatchesDTO
+{
+    public class SimpleMatchResultDTO
+    {
+        public string TeamA { get; set; } = string.Empty;
+        public string TeamB { get; set; } = string.Empty;
+        public MatchOutcome Winner { get; set; }
+        public int? WinnerID { get; set; }
+        public double OutcomeProbability { get; set; }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/MatchesDTO/SimpleSimulationMatchDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/MatchesDTO/SimpleSimulationMatchDTO.cs
@@ -1,0 +1,14 @@
+﻿namespace WCS.Application.DTO.MatchesDTO
+{
+    public class SimpleSimulationMatchDTO
+    {
+        public int TeamAID { get; set; }
+        public string TeamA { get; set; } = string.Empty;        
+        public double AAttackRating { get; set; }
+        public double ADefenseRating { get; set; }
+        public int TeamBID { get; set; }
+        public string TeamB { get; set; } = string.Empty;
+        public double BAttackRating { get; set; }
+        public double BDefenseRating { get; set; }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/ProbabilitiesDTO/MatchProbabilityDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/ProbabilitiesDTO/MatchProbabilityDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace WCS.Application.DTO.ProbabilitiesDTO
 {
-    public class MatchProbabilityTableDTO
+    public class MatchProbabilityDTO
     {
         public List<ScoreProbabilityDTO> Scores { get; set; } = [];
         public double WinA { get; set; }

--- a/WorldCupSimulatorApp/WCS.Application/DTO/ProbabilitiesDTO/MatchProbabilityDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/ProbabilitiesDTO/MatchProbabilityDTO.cs
@@ -1,0 +1,10 @@
+﻿namespace WCS.Application.DTO.ProbabilitiesDTO
+{
+    public class MatchProbabilityTableDTO
+    {
+        public List<ScoreProbabilityDTO> Scores { get; set; } = [];
+        public double WinA { get; set; }
+        public double Draw { get; set; }
+        public double WinB { get; set; }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/ProbabilitiesDTO/ScoreProbabilityDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/ProbabilitiesDTO/ScoreProbabilityDTO.cs
@@ -1,0 +1,9 @@
+﻿namespace WCS.Application.DTO.ProbabilitiesDTO
+{
+    public class ScoreProbabilityDTO
+    {
+        public int GoalsA { get; set; }
+        public int GoalsB { get; set; }
+        public double Probability { get; set; }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/RatingsDTO/AdaptativeRatingsDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/RatingsDTO/AdaptativeRatingsDTO.cs
@@ -1,0 +1,12 @@
+﻿namespace WCS.Application.DTO.RatingsDTO
+{
+    public class AdaptativeRatingsDTO
+    {
+        public double LambdaA { get; set; }
+        public double LambdaB { get; set; }
+        public AttackRatingDTO AAttackRating { get; set; } = new AttackRatingDTO();
+        public DefenseRatingDTO ADefenseRating { get; set; } = new DefenseRatingDTO();
+        public AttackRatingDTO BAttackRating { get; set; } = new AttackRatingDTO();
+        public DefenseRatingDTO BDefenseRating { get; set; } = new DefenseRatingDTO();
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/RatingsDTO/AttackRatingDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/RatingsDTO/AttackRatingDTO.cs
@@ -1,0 +1,9 @@
+﻿namespace WCS.Application.DTO.RatingsDTO
+{
+    public class AttackRatingDTO
+    {
+        public double AttackRating{ get; set; }
+        public double AccumulatedScores { get; set; }
+        public double AccumulatedWeights { get; set; }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/RatingsDTO/DefenseRatingDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/RatingsDTO/DefenseRatingDTO.cs
@@ -4,6 +4,6 @@
     {
         public double DefenseRating { get; set; }
         public double AccumulatedPenalties { get; set; }
-        public double AccumulatedCount { get; set; }
+        public int AccumulatedCount { get; set; }
     }
 }

--- a/WorldCupSimulatorApp/WCS.Application/DTO/RatingsDTO/DefenseRatingDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/RatingsDTO/DefenseRatingDTO.cs
@@ -1,0 +1,9 @@
+﻿namespace WCS.Application.DTO.RatingsDTO
+{
+    public class DefenseRatingDTO
+    {
+        public double DefenseRating { get; set; }
+        public double AccumulatedPenalties { get; set; }
+        public double AccumulatedCount { get; set; }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/RatingsDTO/RatingDataDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/RatingsDTO/RatingDataDTO.cs
@@ -4,6 +4,7 @@ namespace WCS.Application.DTO.RatingsDTO
 {
     public class RatingDataDTO
     {
+        public int TeamID { get; set; }
         public int GoalsScored { get; set; }
         public int GoalsConceded { get; set; }
         public int OpponentFifaRank { get; set; }

--- a/WorldCupSimulatorApp/WCS.Application/DTO/RatingsDTO/RatingDataDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/RatingsDTO/RatingDataDTO.cs
@@ -1,0 +1,16 @@
+﻿using WCS.Domain.Enums;
+
+namespace WCS.Application.DTO.RatingsDTO
+{
+    public class RatingDataDTO
+    {
+        public int GoalsScored { get; set; }
+        public int GoalsConceded { get; set; }
+        public int OpponentFifaRank { get; set; }
+        public double OpponentAttackRating { get; set; }
+        public DateOnly Date { get; set; }
+        public Competition Competition { get; set; }
+        public Stage Stage { get; set; }
+
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/Services/Common/MathHelpers.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Common/MathHelpers.cs
@@ -1,0 +1,17 @@
+﻿namespace WCS.Application.Services.Common
+{
+    public class MathHelpers
+    {
+        public static double CalculateFactorial(int n)
+        {
+            if (n < 0) throw new ArgumentException("n must be greater than 0.");
+
+            double factorial = 1;
+            for (int i = 1; i <= n; i++)
+            {
+                factorial *= i;
+            }
+            return factorial;
+        }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/Services/Probabilities/IMatchProbabilityService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Probabilities/IMatchProbabilityService.cs
@@ -1,0 +1,11 @@
+﻿using WCS.Application.DTO.ProbabilitiesDTO;
+
+namespace WCS.Application.Services.Probabilities
+{
+    public interface IMatchProbabilityService
+    {
+        double CalculateLambda(double attackRating, double opponentDefenseRating);
+
+        List<ScoreProbabilityDTO> CalculateMatchProbabilities(int maxGoals, double lambdaA, double lambdaB);
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/Services/Probabilities/IMatchProbabilityService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Probabilities/IMatchProbabilityService.cs
@@ -1,4 +1,5 @@
 ﻿using WCS.Application.DTO.ProbabilitiesDTO;
+using WCS.Domain.Enums;
 
 namespace WCS.Application.Services.Probabilities
 {
@@ -6,6 +7,10 @@ namespace WCS.Application.Services.Probabilities
     {
         double CalculateLambda(double attackRating, double opponentDefenseRating);
 
-        List<ScoreProbabilityDTO> CalculateMatchProbabilities(int maxGoals, double lambdaA, double lambdaB);
+        MatchProbabilityDTO CalculateMatchProbabilities(int maxGoals, double lambdaA, double lambdaB);
+
+        ScoreProbabilityDTO PickRandomScore(List<ScoreProbabilityDTO> scores);
+
+        MatchOutcome PickRandomOutcome(MatchProbabilityDTO match);
     }
 }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Probabilities/MatchProbabilityService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Probabilities/MatchProbabilityService.cs
@@ -1,5 +1,6 @@
 ﻿using WCS.Application.DTO.ProbabilitiesDTO;
 using WCS.Application.Services.Common;
+using WCS.Domain.Enums;
 
 namespace WCS.Application.Services.Probabilities
 {
@@ -58,12 +59,15 @@ namespace WCS.Application.Services.Probabilities
             return scores;
         }
 
-        public List<ScoreProbabilityDTO> CalculateMatchProbabilities (int maxGoals, double lambdaA, double lambdaB)
+        public MatchProbabilityDTO CalculateMatchProbabilities (int maxGoals, double lambdaA, double lambdaB)
         {
             if (maxGoals < 0)
                 throw new ArgumentException("maxGoals cannot be negative.");
 
             var scores = GenerateTable(maxGoals);
+            double winA = 0;
+            double draw = 0;
+            double winB = 0;
 
             foreach (var score in scores)
             {
@@ -76,9 +80,62 @@ namespace WCS.Application.Services.Probabilities
             foreach (var score in scores)
             {
                 score.Probability /= totalProbability;
+                if (score.GoalsA > score.GoalsB)
+                {
+                    winA += score.Probability;
+                }
+                else if (score.GoalsA < score.GoalsB)
+                {
+                    winB += score.Probability;
+                }
+                else
+                {
+                    draw += score.Probability;
+                }
             }
 
-            return scores;
+            return new MatchProbabilityDTO
+            {
+                Scores = scores,
+                WinA = winA,
+                Draw = draw,
+                WinB = winB
+            };
+        }
+
+        public ScoreProbabilityDTO PickRandomScore(List<ScoreProbabilityDTO> scores)
+        {
+            if (scores == null || scores.Count == 0)
+                throw new ArgumentException("Scores list is empty.");
+
+            double roll = Random.Shared.NextDouble();
+            double cumulative = 0;
+
+            foreach (var score in scores)
+            {
+                cumulative += score.Probability;
+
+                if (roll <= cumulative)
+                    return score;
+            }
+
+            return scores[^1];
+        }
+
+        public MatchOutcome PickRandomOutcome(MatchProbabilityDTO match)
+        {
+            if (match == null || (match.WinA == 0 && match.Draw == 0 && match.WinB == 0))
+                throw new ArgumentException("Match is empty.");
+
+            double roll = Random.Shared.NextDouble();
+
+            if (roll <= match.WinA)
+                return MatchOutcome.WinA;
+
+            if (roll <= match.WinA + match.Draw)
+                return MatchOutcome.Draw;
+
+            return MatchOutcome.WinB;
         }
     }
 }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Probabilities/MatchProbabilityService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Probabilities/MatchProbabilityService.cs
@@ -1,0 +1,84 @@
+﻿using WCS.Application.DTO.ProbabilitiesDTO;
+using WCS.Application.Services.Common;
+
+namespace WCS.Application.Services.Probabilities
+{
+    public class MatchProbabilityService : IMatchProbabilityService
+    {
+        public double CalculateLambda(double attackRating, double opponentDefenseRating)
+        {
+            if (opponentDefenseRating == 0)
+                throw new ArgumentException("Defense rating must be greater than zero.");
+
+            return (attackRating / opponentDefenseRating);
+        }
+
+        private static double CalculateProbability (double lambdaA, double lambdaB, int goalsA, int goalsB)
+        {
+            if (goalsA < 0 || goalsB < 0)
+                throw new ArgumentException("Goals cannot be negative.");
+
+            var factorialA = MathHelpers.CalculateFactorial(goalsA);
+            var factorialB = MathHelpers.CalculateFactorial(goalsB);
+
+            double probGoalsA = 
+                (Math.Exp(-lambdaA) *
+                Math.Pow(lambdaA, goalsA))
+                / factorialA;
+
+            double probGoalsB = 
+                (Math.Exp(-lambdaB) *
+                Math.Pow(lambdaB, goalsB))
+                / factorialB;
+            
+            return probGoalsA * probGoalsB;
+        }
+
+        private static List<ScoreProbabilityDTO> GenerateTable (int maxGoals)
+        {
+            if (maxGoals < 0)
+                throw new ArgumentException("maxGoals cannot be negative.");
+
+            var scores = new List<ScoreProbabilityDTO>();
+
+            for (int i = 0; i <= maxGoals; i++)
+            {
+                for (int j = 0; j <= maxGoals; j++)
+                {
+                    var score = new ScoreProbabilityDTO
+                    {
+                        GoalsA = i,
+                        GoalsB = j,
+                    };
+
+                    scores.Add(score);
+                }                
+            }
+
+            return scores;
+        }
+
+        public List<ScoreProbabilityDTO> CalculateMatchProbabilities (int maxGoals, double lambdaA, double lambdaB)
+        {
+            if (maxGoals < 0)
+                throw new ArgumentException("maxGoals cannot be negative.");
+
+            var scores = GenerateTable(maxGoals);
+
+            foreach (var score in scores)
+            {
+                var probability = CalculateProbability(lambdaA, lambdaB, score.GoalsA, score.GoalsB);
+                score.Probability = probability;
+            }
+
+            var totalProbability = scores.Sum(x => x.Probability);
+
+            foreach (var score in scores)
+            {
+                score.Probability /= totalProbability;
+            }
+
+            return scores;
+        }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
@@ -1,19 +1,11 @@
-﻿using Microsoft.Extensions.Options;
-using WCS.Application.DTO.RatingsDTO;
+﻿using WCS.Application.DTO.RatingsDTO;
 using WCS.Domain.Entities;
 
 namespace WCS.Application.Services.Ratings
 {
     public class AttackRatingCalculator
     {
-        private readonly RatingWeightsOptions _RatingWeights;
-
-        public AttackRatingCalculator(IOptions<RatingWeightsOptions> options)
-        {
-            _RatingWeights = options.Value;
-        }
-
-        public double Calculate(List<RatingDataDTO> data)
+        public double Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights)
         {
             if (data == null || data.Count == 0) return 0;
 
@@ -28,28 +20,31 @@ namespace WCS.Application.Services.Ratings
                 double recencyWeight = helper.GetRecencyWeight(match.Date);
                 double rivalWeight = helper.GetRankingWeight(match.OpponentFifaRank);
 
-                if (!_RatingWeights.Competition.TryGetValue(
+                if (!weights.Competition.TryGetValue(
                     match.Competition.ToString(),
                     out var competitionWeight))
                 {
                     competitionWeight = 0.85;
                 }
 
-                if (!_RatingWeights.Stage.TryGetValue(
+                if (!weights.Stage.TryGetValue(
                     match.Stage.ToString(),
                     out var stageWeight))
                 {
                     stageWeight = 1;
                 }
 
+                // Combined importance of the match.
                 double totalWeight = recencyWeight * rivalWeight * competitionWeight * stageWeight;
 
+                // Offensive contribution adjusted by match importance.
                 score = match.GoalsScored * totalWeight;
 
                 sumScores += score;
                 sumWeights += totalWeight;
             }
 
+            // Weighted average goals scored.
             return sumWeights == 0 ? 0 : sumScores / sumWeights;
         }
     }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
@@ -55,10 +55,10 @@ namespace WCS.Application.Services.Ratings
             };
         }
 
-        public static double Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, double accumulatedScores,
+        public static AttackRatingDTO Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, double accumulatedScores,
             double accumulatedWeights)
         {
-            if (data == null || data.Count == 0) return 0;
+            if (data == null || data.Count == 0) return new AttackRatingDTO();
 
             var helper = new RatingHelper();
 
@@ -96,7 +96,14 @@ namespace WCS.Application.Services.Ratings
             }
 
             // Weighted average goals scored.
-            return sumWeights == 0 ? 0 : sumScores / sumWeights;
+            var attackRating = sumWeights == 0 ? 0 : sumScores / sumWeights;
+
+            return new AttackRatingDTO
+            {
+                AttackRating = attackRating,
+                AccumulatedScores = sumScores,
+                AccumulatedWeights = sumWeights,
+            };
         }
     }
 }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
@@ -5,14 +5,65 @@ namespace WCS.Application.Services.Ratings
 {
     public class AttackRatingCalculator
     {
-        public static double Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights)
+        public static AttackRatingDTO CalculateHistorical(List<RatingDataDTO> data, RatingWeightsOptions weights)
         {
-            if (data == null || data.Count == 0) return 0;
+            if (data == null || data.Count == 0) return new AttackRatingDTO();
 
             var helper = new RatingHelper();
 
             double sumWeights = 0;
             double sumScores = 0;
+
+            foreach (var match in data)
+            {
+                double score = 0;
+                double recencyWeight = helper.GetRecencyWeight(match.Date);
+                double rivalWeight = helper.GetRankingWeight(match.OpponentFifaRank);
+
+                if (!weights.Competition.TryGetValue(
+                    match.Competition.ToString(),
+                    out var competitionWeight))
+                {
+                    competitionWeight = 0.85;
+                }
+
+                if (!weights.Stage.TryGetValue(
+                    match.Stage.ToString(),
+                    out var stageWeight))
+                {
+                    stageWeight = 1;
+                }
+
+                // Combined importance of the match.
+                double totalWeight = recencyWeight * rivalWeight * competitionWeight * stageWeight;
+
+                // Offensive contribution adjusted by match importance.
+                score = match.GoalsScored * totalWeight;
+
+                sumScores += score;
+                sumWeights += totalWeight;
+            }
+
+            // Weighted average goals scored.
+            var attackRating = sumWeights == 0 ? 0 : sumScores / sumWeights;
+
+            return new AttackRatingDTO
+            {
+                AttackRating = attackRating,
+                AccumulatedScores = sumScores,
+                AccumulatedWeights = sumWeights,
+            };
+        }
+
+        public static double Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, double accumulatedScores,
+            double accumulatedWeights)
+        {
+            if (data == null || data.Count == 0) return 0;
+
+            var helper = new RatingHelper();
+
+            double sumWeights = accumulatedWeights;
+            double sumScores = accumulatedScores;
 
             foreach (var match in data)
             {

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
@@ -5,8 +5,8 @@ namespace WCS.Application.Services.Ratings
 {
     public class AttackRatingCalculator
     {
-        public static AttackRatingDTO Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, double? accumulatedScores,
-            double? accumulatedWeights)
+        public static AttackRatingDTO Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, 
+            double accumulatedScores, double accumulatedWeights)
         {
             if (data == null || data.Count == 0) return new AttackRatingDTO();
 
@@ -15,10 +15,10 @@ namespace WCS.Application.Services.Ratings
             double sumWeights = 0;
             double sumScores = 0;
 
-            if (accumulatedScores != null && accumulatedWeights != null && accumulatedScores > 0 && accumulatedWeights > 0)
+            if (accumulatedScores > 0 && accumulatedWeights > 0)
             {
-                sumWeights = accumulatedWeights.Value;
-                sumScores = accumulatedScores.Value;
+                sumWeights = accumulatedWeights;
+                sumScores = accumulatedScores;
             }
 
             foreach (var match in data)

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Extensions.Options;
+using WCS.Application.DTO.RatingsDTO;
+using WCS.Domain.Entities;
+
+namespace WCS.Application.Services.Ratings
+{
+    public class AttackRatingCalculator
+    {
+        private readonly RatingWeightsOptions _RatingWeights;
+
+        public AttackRatingCalculator(IOptions<RatingWeightsOptions> options)
+        {
+            _RatingWeights = options.Value;
+        }
+
+        public double Calculate(List<RatingDataDTO> data)
+        {
+            if (data == null || data.Count == 0) return 0;
+
+            var helper = new RatingHelper();
+
+            double sumWeights = 0;
+            double sumScores = 0;
+
+            foreach (var match in data)
+            {
+                double score = 0;
+                double recencyWeight = helper.GetRecencyWeight(match.Date);
+                double rivalWeight = helper.GetRankingWeight(match.OpponentFifaRank);
+
+                if (!_RatingWeights.Competition.TryGetValue(
+                    match.Competition.ToString(),
+                    out var competitionWeight))
+                {
+                    competitionWeight = 0.85;
+                }
+
+                if (!_RatingWeights.Stage.TryGetValue(
+                    match.Stage.ToString(),
+                    out var stageWeight))
+                {
+                    stageWeight = 1;
+                }
+
+                double totalWeight = recencyWeight * rivalWeight * competitionWeight * stageWeight;
+
+                score = match.GoalsScored * totalWeight;
+
+                sumScores += score;
+                sumWeights += totalWeight;
+            }
+
+            return sumWeights == 0 ? 0 : sumScores / sumWeights;
+        }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
@@ -5,7 +5,7 @@ namespace WCS.Application.Services.Ratings
 {
     public class AttackRatingCalculator
     {
-        public double Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights)
+        public static double Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights)
         {
             if (data == null || data.Count == 0) return 0;
 

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/AttackRatingCalculator.cs
@@ -5,7 +5,8 @@ namespace WCS.Application.Services.Ratings
 {
     public class AttackRatingCalculator
     {
-        public static AttackRatingDTO CalculateHistorical(List<RatingDataDTO> data, RatingWeightsOptions weights)
+        public static AttackRatingDTO Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, double? accumulatedScores,
+            double? accumulatedWeights)
         {
             if (data == null || data.Count == 0) return new AttackRatingDTO();
 
@@ -14,56 +15,11 @@ namespace WCS.Application.Services.Ratings
             double sumWeights = 0;
             double sumScores = 0;
 
-            foreach (var match in data)
+            if (accumulatedScores != null && accumulatedWeights != null && accumulatedScores > 0 && accumulatedWeights > 0)
             {
-                double score = 0;
-                double recencyWeight = helper.GetRecencyWeight(match.Date);
-                double rivalWeight = helper.GetRankingWeight(match.OpponentFifaRank);
-
-                if (!weights.Competition.TryGetValue(
-                    match.Competition.ToString(),
-                    out var competitionWeight))
-                {
-                    competitionWeight = 0.85;
-                }
-
-                if (!weights.Stage.TryGetValue(
-                    match.Stage.ToString(),
-                    out var stageWeight))
-                {
-                    stageWeight = 1;
-                }
-
-                // Combined importance of the match.
-                double totalWeight = recencyWeight * rivalWeight * competitionWeight * stageWeight;
-
-                // Offensive contribution adjusted by match importance.
-                score = match.GoalsScored * totalWeight;
-
-                sumScores += score;
-                sumWeights += totalWeight;
+                sumWeights = accumulatedWeights.Value;
+                sumScores = accumulatedScores.Value;
             }
-
-            // Weighted average goals scored.
-            var attackRating = sumWeights == 0 ? 0 : sumScores / sumWeights;
-
-            return new AttackRatingDTO
-            {
-                AttackRating = attackRating,
-                AccumulatedScores = sumScores,
-                AccumulatedWeights = sumWeights,
-            };
-        }
-
-        public static AttackRatingDTO Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, double accumulatedScores,
-            double accumulatedWeights)
-        {
-            if (data == null || data.Count == 0) return new AttackRatingDTO();
-
-            var helper = new RatingHelper();
-
-            double sumWeights = accumulatedWeights;
-            double sumScores = accumulatedScores;
 
             foreach (var match in data)
             {

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.Extensions.Options;
+using WCS.Application.DTO.RatingsDTO;
+using WCS.Domain.Entities;
+
+namespace WCS.Application.Services.Ratings
+{
+    public class DefenseRatingCalculator
+    {
+        private readonly RatingWeightsOptions _RatingWeights;
+
+        public DefenseRatingCalculator(IOptions<RatingWeightsOptions> options)
+        {
+            _RatingWeights = options.Value;
+        }
+
+        public double Calculate(List<RatingDataDTO> data)
+        {
+            if (data == null || data.Count == 0) return 0;
+
+            var helper = new RatingHelper();
+
+            double sumPenalties = 0;
+            int count = 0;
+
+            foreach (var match in data)
+            {
+                double penalty = 0;
+                double recencyWeight = helper.GetRecencyWeight(match.Date);
+                double rivalWeight = helper.GetRankingWeight(match.OpponentFifaRank);
+
+                var attack = Math.Max(0.25, match.OpponentAttackRating);
+
+                if (!_RatingWeights.Competition.TryGetValue(
+                    match.Competition.ToString(),
+                    out var competitionWeight))
+                {
+                    competitionWeight = 0.85;
+                }
+
+                if (!_RatingWeights.Stage.TryGetValue(
+                    match.Stage.ToString(),
+                    out var stageWeight))
+                {
+                    stageWeight = 1;
+                }
+
+                double totalWeight = recencyWeight * rivalWeight * competitionWeight * stageWeight;
+
+                penalty = match.GoalsConceded * totalWeight / attack;
+
+                sumPenalties += penalty;
+                count++;
+            }
+
+            double avgPenalty = sumPenalties/count;
+
+            return 2.5 / (1 + avgPenalty);
+        }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
@@ -5,7 +5,7 @@ namespace WCS.Application.Services.Ratings
 {
     public class DefenseRatingCalculator
     {
-        public double Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights)
+        public static double Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights)
         {
             if (data == null || data.Count == 0) return 0;
 

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
@@ -5,9 +5,9 @@ namespace WCS.Application.Services.Ratings
 {
     public class DefenseRatingCalculator
     {
-        public static double Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights)
+        public static DefenseRatingDTO CalculateHistorical(List<RatingDataDTO> data, RatingWeightsOptions weights)
         {
-            if (data == null || data.Count == 0) return 0;
+            if (data == null || data.Count == 0) return new DefenseRatingDTO();
 
             var helper = new RatingHelper();
 
@@ -49,6 +49,65 @@ namespace WCS.Application.Services.Ratings
             }
 
             double avgPenalty = sumPenalties/count;
+
+            // Converts penalties into defensive rating.
+            // 2.5 is the current max baseline and can be adjusted later.
+            const double MaxDefenseRating = 2.5;
+            var defenseRating = MaxDefenseRating / (1 + avgPenalty);
+
+            return new DefenseRatingDTO
+            {
+                DefenseRating = defenseRating,
+                AccumulatedPenalties = sumPenalties,
+                AccumulatedCount = count
+            };
+        }
+
+        public static double Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, double accumulatedPenalties,
+            int accumulatedCount)
+        {
+            if (data == null || data.Count == 0) return 0;
+
+            var helper = new RatingHelper();
+
+            double sumPenalties = accumulatedPenalties;
+            int count = accumulatedCount;
+
+            foreach (var match in data)
+            {
+                double recencyWeight = helper.GetRecencyWeight(match.Date);
+                double rivalWeight = helper.GetRankingWeight(match.OpponentFifaRank);
+
+                // Prevent division by zero and extreme values from weak opponents.
+                var attack = Math.Max(0.25, match.OpponentAttackRating);
+
+                if (!weights.Competition.TryGetValue(
+                    match.Competition.ToString(),
+                    out var competitionWeight))
+                {
+                    competitionWeight = 0.85;
+                }
+
+                if (!weights.Stage.TryGetValue(
+                    match.Stage.ToString(),
+                    out var stageWeight))
+                {
+                    stageWeight = 1;
+                }
+
+                // Combined importance of the match.
+                double totalWeight = recencyWeight * rivalWeight * competitionWeight * stageWeight;
+
+                // Defensive penalty:
+                // conceding goals against weak attacks penalizes more,
+                // conceding against strong attacks penalizes less.
+                double penalty = match.GoalsConceded * totalWeight / attack;
+
+                sumPenalties += penalty;
+                count++;
+            }
+
+            double avgPenalty = sumPenalties / count;
 
             // Converts penalties into defensive rating.
             // 2.5 is the current max baseline and can be adjusted later.

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
@@ -63,10 +63,10 @@ namespace WCS.Application.Services.Ratings
             };
         }
 
-        public static double Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, double accumulatedPenalties,
+        public static DefenseRatingDTO Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, double accumulatedPenalties,
             int accumulatedCount)
         {
-            if (data == null || data.Count == 0) return 0;
+            if (data == null || data.Count == 0) return new DefenseRatingDTO();
 
             var helper = new RatingHelper();
 
@@ -112,7 +112,14 @@ namespace WCS.Application.Services.Ratings
             // Converts penalties into defensive rating.
             // 2.5 is the current max baseline and can be adjusted later.
             const double MaxDefenseRating = 2.5;
-            return MaxDefenseRating / (1 + avgPenalty);
+            var defenseRating = MaxDefenseRating / (1 + avgPenalty);
+
+            return new DefenseRatingDTO
+            {
+                DefenseRating = defenseRating,
+                AccumulatedPenalties = sumPenalties,
+                AccumulatedCount = count
+            };
         }
     }
 }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
@@ -5,8 +5,8 @@ namespace WCS.Application.Services.Ratings
 {
     public class DefenseRatingCalculator
     {
-        public static DefenseRatingDTO Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, double? accumulatedPenalties,
-            int? accumulatedCount)
+        public static DefenseRatingDTO Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights,
+            double accumulatedPenalties, int accumulatedCount)
         {
             if (data == null || data.Count == 0) return new DefenseRatingDTO();
 
@@ -15,10 +15,10 @@ namespace WCS.Application.Services.Ratings
             double sumPenalties = 0;
             int count = 0;
 
-            if (accumulatedPenalties != null && accumulatedCount != null && accumulatedPenalties > 0 && accumulatedCount > 0)
+            if (accumulatedPenalties > 0 && accumulatedCount > 0)
             {
-                sumPenalties = accumulatedPenalties.Value;
-                count = accumulatedCount.Value;
+                sumPenalties = accumulatedPenalties;
+                count = accumulatedCount;
             } 
 
             foreach (var match in data)

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
@@ -5,7 +5,8 @@ namespace WCS.Application.Services.Ratings
 {
     public class DefenseRatingCalculator
     {
-        public static DefenseRatingDTO CalculateHistorical(List<RatingDataDTO> data, RatingWeightsOptions weights)
+        public static DefenseRatingDTO Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, double? accumulatedPenalties,
+            int? accumulatedCount)
         {
             if (data == null || data.Count == 0) return new DefenseRatingDTO();
 
@@ -14,64 +15,11 @@ namespace WCS.Application.Services.Ratings
             double sumPenalties = 0;
             int count = 0;
 
-            foreach (var match in data)
+            if (accumulatedPenalties != null && accumulatedCount != null && accumulatedPenalties > 0 && accumulatedCount > 0)
             {
-                double recencyWeight = helper.GetRecencyWeight(match.Date);
-                double rivalWeight = helper.GetRankingWeight(match.OpponentFifaRank);
-
-                // Prevent division by zero and extreme values from weak opponents.
-                var attack = Math.Max(0.25, match.OpponentAttackRating);
-
-                if (!weights.Competition.TryGetValue(
-                    match.Competition.ToString(),
-                    out var competitionWeight))
-                {
-                    competitionWeight = 0.85;
-                }
-
-                if (!weights.Stage.TryGetValue(
-                    match.Stage.ToString(),
-                    out var stageWeight))
-                {
-                    stageWeight = 1;
-                }
-
-                // Combined importance of the match.
-                double totalWeight = recencyWeight * rivalWeight * competitionWeight * stageWeight;
-
-                // Defensive penalty:
-                // conceding goals against weak attacks penalizes more,
-                // conceding against strong attacks penalizes less.
-                double penalty = match.GoalsConceded * totalWeight / attack;
-
-                sumPenalties += penalty;
-                count++;
-            }
-
-            double avgPenalty = sumPenalties/count;
-
-            // Converts penalties into defensive rating.
-            // 2.5 is the current max baseline and can be adjusted later.
-            const double MaxDefenseRating = 2.5;
-            var defenseRating = MaxDefenseRating / (1 + avgPenalty);
-
-            return new DefenseRatingDTO
-            {
-                DefenseRating = defenseRating,
-                AccumulatedPenalties = sumPenalties,
-                AccumulatedCount = count
-            };
-        }
-
-        public static DefenseRatingDTO Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights, double accumulatedPenalties,
-            int accumulatedCount)
-        {
-            if (data == null || data.Count == 0) return new DefenseRatingDTO();
-
-            var helper = new RatingHelper();
-
-            double sumPenalties = accumulatedPenalties;
-            int count = accumulatedCount;
+                sumPenalties = accumulatedPenalties.Value;
+                count = accumulatedCount.Value;
+            } 
 
             foreach (var match in data)
             {

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/DefenseRatingCalculator.cs
@@ -1,19 +1,11 @@
-﻿using Microsoft.Extensions.Options;
-using WCS.Application.DTO.RatingsDTO;
+﻿using WCS.Application.DTO.RatingsDTO;
 using WCS.Domain.Entities;
 
 namespace WCS.Application.Services.Ratings
 {
     public class DefenseRatingCalculator
     {
-        private readonly RatingWeightsOptions _RatingWeights;
-
-        public DefenseRatingCalculator(IOptions<RatingWeightsOptions> options)
-        {
-            _RatingWeights = options.Value;
-        }
-
-        public double Calculate(List<RatingDataDTO> data)
+        public double Calculate(List<RatingDataDTO> data, RatingWeightsOptions weights)
         {
             if (data == null || data.Count == 0) return 0;
 
@@ -24,29 +16,33 @@ namespace WCS.Application.Services.Ratings
 
             foreach (var match in data)
             {
-                double penalty = 0;
                 double recencyWeight = helper.GetRecencyWeight(match.Date);
                 double rivalWeight = helper.GetRankingWeight(match.OpponentFifaRank);
 
+                // Prevent division by zero and extreme values from weak opponents.
                 var attack = Math.Max(0.25, match.OpponentAttackRating);
 
-                if (!_RatingWeights.Competition.TryGetValue(
+                if (!weights.Competition.TryGetValue(
                     match.Competition.ToString(),
                     out var competitionWeight))
                 {
                     competitionWeight = 0.85;
                 }
 
-                if (!_RatingWeights.Stage.TryGetValue(
+                if (!weights.Stage.TryGetValue(
                     match.Stage.ToString(),
                     out var stageWeight))
                 {
                     stageWeight = 1;
                 }
 
+                // Combined importance of the match.
                 double totalWeight = recencyWeight * rivalWeight * competitionWeight * stageWeight;
 
-                penalty = match.GoalsConceded * totalWeight / attack;
+                // Defensive penalty:
+                // conceding goals against weak attacks penalizes more,
+                // conceding against strong attacks penalizes less.
+                double penalty = match.GoalsConceded * totalWeight / attack;
 
                 sumPenalties += penalty;
                 count++;
@@ -54,7 +50,10 @@ namespace WCS.Application.Services.Ratings
 
             double avgPenalty = sumPenalties/count;
 
-            return 2.5 / (1 + avgPenalty);
+            // Converts penalties into defensive rating.
+            // 2.5 is the current max baseline and can be adjusted later.
+            const double MaxDefenseRating = 2.5;
+            return MaxDefenseRating / (1 + avgPenalty);
         }
     }
 }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/IRatingService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/IRatingService.cs
@@ -1,0 +1,11 @@
+﻿using WCS.Application.DTO.RatingsDTO;
+
+namespace WCS.Application.Services.Ratings
+{
+    public interface IRatingService
+    {
+        double CalculateAttack(List<RatingDataDTO> data);
+        double CalculateDefense(List<RatingDataDTO> data);
+
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/IRatingService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/IRatingService.cs
@@ -5,9 +5,9 @@ namespace WCS.Application.Services.Ratings
     public interface IRatingService
     {
         AttackRatingDTO CalculateHistoricalAttack(List<RatingDataDTO> data);
-        double CalculateAttack(List<RatingDataDTO> data, double accumulatedScores, double accumulatedWeights);
+        AttackRatingDTO CalculateAttack(List<RatingDataDTO> data, double accumulatedScores, double accumulatedWeights);
         DefenseRatingDTO CalculateHistoricalDefense(List<RatingDataDTO> data);
-        double CalculateDefense(List<RatingDataDTO> data, double accumulatedPenalties, int accumulatedCount);
+        DefenseRatingDTO CalculateDefense(List<RatingDataDTO> data, double accumulatedPenalties, int accumulatedCount);
 
     }
 }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/IRatingService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/IRatingService.cs
@@ -4,8 +4,10 @@ namespace WCS.Application.Services.Ratings
 {
     public interface IRatingService
     {
-        double CalculateAttack(List<RatingDataDTO> data);
-        double CalculateDefense(List<RatingDataDTO> data);
+        AttackRatingDTO CalculateHistoricalAttack(List<RatingDataDTO> data);
+        double CalculateAttack(List<RatingDataDTO> data, double accumulatedScores, double accumulatedWeights);
+        DefenseRatingDTO CalculateHistoricalDefense(List<RatingDataDTO> data);
+        double CalculateDefense(List<RatingDataDTO> data, double accumulatedPenalties, int accumulatedCount);
 
     }
 }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/IRatingService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/IRatingService.cs
@@ -4,9 +4,7 @@ namespace WCS.Application.Services.Ratings
 {
     public interface IRatingService
     {
-        AttackRatingDTO CalculateHistoricalAttack(List<RatingDataDTO> data);
         AttackRatingDTO CalculateAttack(List<RatingDataDTO> data, double accumulatedScores, double accumulatedWeights);
-        DefenseRatingDTO CalculateHistoricalDefense(List<RatingDataDTO> data);
         DefenseRatingDTO CalculateDefense(List<RatingDataDTO> data, double accumulatedPenalties, int accumulatedCount);
 
     }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingHelper.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingHelper.cs
@@ -2,11 +2,15 @@
 {
     public class RatingHelper
     {
+        // Converts FIFA rank into opponent strength weight.
+        // Better rank (lower number) => higher weight.
+        // Output range limited between 0.5 and 2.0.
         public double GetRankingWeight(int rank)
         {
             return Math.Clamp(2.2 - (rank / 100.0), 0.5, 2.0);
         }
 
+        // Applies recency weighting to prioritize recent matches.
         public double GetRecencyWeight(DateOnly date)
         {
             var years = (DateTime.Today - date.ToDateTime(TimeOnly.MinValue)).TotalDays / 365.25;

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingHelper.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingHelper.cs
@@ -1,0 +1,20 @@
+﻿namespace WCS.Application.Services.Ratings
+{
+    public class RatingHelper
+    {
+        public double GetRankingWeight(int rank)
+        {
+            return Math.Clamp(2.2 - (rank / 100.0), 0.5, 2.0);
+        }
+
+        public double GetRecencyWeight(DateOnly date)
+        {
+            var years = (DateTime.Today - date.ToDateTime(TimeOnly.MinValue)).TotalDays / 365.25;
+
+            if (years <= 1) return 1.00;
+            if (years <= 2) return 0.85;
+            if (years <= 3) return 0.70;
+            return 0.55;
+        }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingService.cs
@@ -8,22 +8,12 @@ namespace WCS.Application.Services.Ratings
     {
         private readonly RatingWeightsOptions _RatingWeights = options.Value;
 
-        public AttackRatingDTO CalculateHistoricalAttack (List<RatingDataDTO> data)
-        {
-            return AttackRatingCalculator.Calculate(data, _RatingWeights, null, null);
-        }
-
-        public AttackRatingDTO CalculateAttack(List<RatingDataDTO> data, double accumulatedScores, double accumulatedWeights)
+        public AttackRatingDTO CalculateAttack(List<RatingDataDTO> data, double accumulatedScores = 0, double accumulatedWeights = 0)
         {
             return AttackRatingCalculator.Calculate(data, _RatingWeights, accumulatedScores, accumulatedWeights);
         }
 
-        public DefenseRatingDTO CalculateHistoricalDefense(List<RatingDataDTO> data)
-        {
-            return DefenseRatingCalculator.Calculate(data, _RatingWeights, null, null);
-        }
-
-        public DefenseRatingDTO CalculateDefense(List<RatingDataDTO> data, double accumulatedPenalties, int accumulatedCount)
+        public DefenseRatingDTO CalculateDefense(List<RatingDataDTO> data, double accumulatedPenalties = 0, int accumulatedCount = 0)
         {
             return DefenseRatingCalculator.Calculate(data, _RatingWeights, accumulatedPenalties, accumulatedCount);
         }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingService.cs
@@ -13,7 +13,7 @@ namespace WCS.Application.Services.Ratings
             return AttackRatingCalculator.CalculateHistorical(data, _RatingWeights);
         }
 
-        public double CalculateAttack(List<RatingDataDTO> data, double accumulatedScores, double accumulatedWeights)
+        public AttackRatingDTO CalculateAttack(List<RatingDataDTO> data, double accumulatedScores, double accumulatedWeights)
         {
             return AttackRatingCalculator.Calculate(data, _RatingWeights, accumulatedScores, accumulatedWeights);
         }
@@ -23,7 +23,7 @@ namespace WCS.Application.Services.Ratings
             return DefenseRatingCalculator.CalculateHistorical(data, _RatingWeights);
         }
 
-        public double CalculateDefense(List<RatingDataDTO> data, double accumulatedPenalties, int accumulatedCount)
+        public DefenseRatingDTO CalculateDefense(List<RatingDataDTO> data, double accumulatedPenalties, int accumulatedCount)
         {
             return DefenseRatingCalculator.Calculate(data, _RatingWeights, accumulatedPenalties, accumulatedCount);
         }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingService.cs
@@ -8,14 +8,24 @@ namespace WCS.Application.Services.Ratings
     {
         private readonly RatingWeightsOptions _RatingWeights = options.Value;
 
-        public double CalculateAttack (List<RatingDataDTO> data)
+        public AttackRatingDTO CalculateHistoricalAttack (List<RatingDataDTO> data)
         {
-            return AttackRatingCalculator.Calculate(data, _RatingWeights);
+            return AttackRatingCalculator.CalculateHistorical(data, _RatingWeights);
         }
 
-        public double CalculateDefense(List<RatingDataDTO> data)
+        public double CalculateAttack(List<RatingDataDTO> data, double accumulatedScores, double accumulatedWeights)
         {
-            return DefenseRatingCalculator.Calculate(data, _RatingWeights);
+            return AttackRatingCalculator.Calculate(data, _RatingWeights, accumulatedScores, accumulatedWeights);
+        }
+
+        public DefenseRatingDTO CalculateHistoricalDefense(List<RatingDataDTO> data)
+        {
+            return DefenseRatingCalculator.CalculateHistorical(data, _RatingWeights);
+        }
+
+        public double CalculateDefense(List<RatingDataDTO> data, double accumulatedPenalties, int accumulatedCount)
+        {
+            return DefenseRatingCalculator.Calculate(data, _RatingWeights, accumulatedPenalties, accumulatedCount);
         }
     }
 }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingService.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Options;
+using WCS.Application.DTO.RatingsDTO;
+using WCS.Domain.Entities;
+
+namespace WCS.Application.Services.Ratings
+{
+    public class RatingService(IOptions<RatingWeightsOptions> options) : IRatingService
+    {
+        private readonly RatingWeightsOptions _RatingWeights = options.Value;
+
+        public double CalculateAttack (List<RatingDataDTO> data)
+        {
+            var calculator = new AttackRatingCalculator();
+            return calculator.Calculate(data, _RatingWeights);
+        }
+
+        public double CalculateDefense(List<RatingDataDTO> data)
+        {
+            var calculator = new DefenseRatingCalculator();
+            return calculator.Calculate(data, _RatingWeights);
+        }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingService.cs
@@ -10,7 +10,7 @@ namespace WCS.Application.Services.Ratings
 
         public AttackRatingDTO CalculateHistoricalAttack (List<RatingDataDTO> data)
         {
-            return AttackRatingCalculator.CalculateHistorical(data, _RatingWeights);
+            return AttackRatingCalculator.Calculate(data, _RatingWeights, null, null);
         }
 
         public AttackRatingDTO CalculateAttack(List<RatingDataDTO> data, double accumulatedScores, double accumulatedWeights)
@@ -20,7 +20,7 @@ namespace WCS.Application.Services.Ratings
 
         public DefenseRatingDTO CalculateHistoricalDefense(List<RatingDataDTO> data)
         {
-            return DefenseRatingCalculator.CalculateHistorical(data, _RatingWeights);
+            return DefenseRatingCalculator.Calculate(data, _RatingWeights, null, null);
         }
 
         public DefenseRatingDTO CalculateDefense(List<RatingDataDTO> data, double accumulatedPenalties, int accumulatedCount)

--- a/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Ratings/RatingService.cs
@@ -10,14 +10,12 @@ namespace WCS.Application.Services.Ratings
 
         public double CalculateAttack (List<RatingDataDTO> data)
         {
-            var calculator = new AttackRatingCalculator();
-            return calculator.Calculate(data, _RatingWeights);
+            return AttackRatingCalculator.Calculate(data, _RatingWeights);
         }
 
         public double CalculateDefense(List<RatingDataDTO> data)
         {
-            var calculator = new DefenseRatingCalculator();
-            return calculator.Calculate(data, _RatingWeights);
+            return DefenseRatingCalculator.Calculate(data, _RatingWeights);
         }
     }
 }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Simulators/ISimulationService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Simulators/ISimulationService.cs
@@ -1,0 +1,19 @@
+﻿using WCS.Application.DTO.MatchesDTO;
+using WCS.Application.DTO.RatingsDTO;
+
+namespace WCS.Application.Services.Simulators
+{
+    public interface I  
+    {
+        List<SimpleMatchResultDTO> SimpleSimulateGroupsStage(List<SimpleSimulationMatchDTO> matches);
+
+        List<SimpleMatchResultDTO> SimpleSimulateKnockouts(List<SimpleSimulationMatchDTO> matches);
+
+        List<MatchResultDTO> SimpleSimulateGroupsStageWithScores(List<SimpleSimulationMatchDTO> matches);
+
+        List<MatchResultDTO> SimpleSimulateKnockoutsWithScores(List<SimpleSimulationMatchDTO> matches);
+
+        List<AdaptativeMatchResultDTO> SimulateAdaptativeKnockoutsWithScores(List<AdaptativeSimulationMatchDTO> matches,
+            List<RatingDataDTO> previousResults);
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/Services/Simulators/ISimulationService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Simulators/ISimulationService.cs
@@ -3,7 +3,7 @@ using WCS.Application.DTO.RatingsDTO;
 
 namespace WCS.Application.Services.Simulators
 {
-    public interface I  
+    public interface ISimulationService 
     {
         List<SimpleMatchResultDTO> SimpleSimulateGroupsStage(List<SimpleSimulationMatchDTO> matches);
 

--- a/WorldCupSimulatorApp/WCS.Application/Services/Simulators/SimulationService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Simulators/SimulationService.cs
@@ -14,11 +14,235 @@ namespace WCS.Application.Services.Simulators
 
         public const int MaxGoals = 6;
 
+        public List<SimpleMatchResultDTO> SimpleSimulateGroupsStage(List<SimpleSimulationMatchDTO> matches)
+        {
+            ValidateMatches(matches);
+
+            var results = new List<SimpleMatchResultDTO>();
+
+            foreach (var match in matches)
+            {
+                var matchProbability = GetProbabilities(match);
+                var winner = _matchProbabilityService.PickRandomOutcome(matchProbability);
+                var result = SimpleBuildResult(match, winner, matchProbability);
+
+                results.Add(result);
+            }
+
+            return results;
+        }
+
+        public List<SimpleMatchResultDTO> SimpleSimulateKnockouts(List<SimpleSimulationMatchDTO> matches)
+        {
+            ValidateMatches(matches);
+
+            var results = new List<SimpleMatchResultDTO>();
+
+            foreach (var match in matches)
+            {
+                var matchProbability = GetProbabilities(match);
+                var winner = PickKnockoutWinner(matchProbability.WinA, matchProbability.WinB);
+                matchProbability.WinA = winner.AProbability;
+                matchProbability.WinB = winner.BProbability;
+                matchProbability.Draw = 0;
+                var result = SimpleBuildResult(match, winner.MatchOutcome, matchProbability);
+
+                results.Add(result);
+            }
+
+            return results;
+        }
+
+        public List<MatchResultDTO> SimpleSimulateGroupsStageWithScores(List<SimpleSimulationMatchDTO> matches)
+        {
+            ValidateMatches(matches);
+
+            var results = new List<MatchResultDTO>();
+
+            foreach (var match in matches)
+            {
+                var matchProbability = GetProbabilities(match);
+                var score = _matchProbabilityService.PickRandomScore(matchProbability.Scores);
+
+                var result = BuildResult(match, score, matchProbability);
+
+                if (score.GoalsA == score.GoalsB)
+                {
+                    result.Winner = MatchOutcome.Draw;
+                    result.WinnerID = null;
+                    result.OutcomeProbability = matchProbability.Draw;
+                }
+
+                results.Add(result);
+            }
+
+            return results;
+        }
+
+        public List<MatchResultDTO> SimpleSimulateKnockoutsWithScores(List<SimpleSimulationMatchDTO> matches)
+        {
+            ValidateMatches(matches);
+
+            var results = new List<MatchResultDTO>();
+
+            foreach (var match in matches)
+            {
+                var matchProbability = GetProbabilities(match);
+                var score = _matchProbabilityService.PickRandomScore(matchProbability.Scores);
+                var winner = PickKnockoutWinner(matchProbability.WinA, matchProbability.WinB);
+
+                var result = BuildResult(match, score, matchProbability);
+
+                if (score.GoalsA == score.GoalsB)
+                {
+                    result.Winner = winner.MatchOutcome;
+
+                    if (winner.MatchOutcome == MatchOutcome.WinA)
+                    {
+                        result.WinnerID = match.TeamAID;
+                        result.OutcomeProbability = winner.AProbability;
+                        result.DecidedByPenalties = true;
+                    }
+                    else
+                    {
+                        result.WinnerID = match.TeamBID;
+                        result.OutcomeProbability = winner.BProbability;
+                        result.DecidedByPenalties = true;
+                    }
+                }
+                results.Add(result);
+            }
+            return results;
+        }       
+
+        public List<AdaptativeMatchResultDTO> SimulateAdaptativeKnockoutsWithScores(List<AdaptativeSimulationMatchDTO> matches,
+            List<RatingDataDTO> previousResults)
+        {
+            ValidateMatches(matches);
+
+            var results = new List<AdaptativeMatchResultDTO>();
+
+            foreach (var match in matches)
+            {
+                var result = new AdaptativeMatchResultDTO
+                {
+                    TeamA = match.TeamA,
+                    TeamB = match.TeamB,
+                };
+
+                var aRatingData = previousResults.Where(r => r.TeamID == match.TeamAID).ToList();
+                var bRatingData = previousResults.Where(r => r.TeamID == match.TeamBID).ToList();
+
+                var AdptRatings = CalculateAdaptativeProbabilities(match, aRatingData, bRatingData);
+
+                var matchProbability = _matchProbabilityService.CalculateMatchProbabilities(MaxGoals, AdptRatings.LambdaA, AdptRatings.LambdaB);
+                var score = _matchProbabilityService.PickRandomScore(matchProbability.Scores);
+
+                result.GoalsA = score.GoalsA;
+                result.GoalsB = score.GoalsB;
+                result.ScoreProbability = score.Probability;
+
+                var winner = PickKnockoutWinner(matchProbability.WinA, matchProbability.WinB);
+
+                if (score.GoalsA > score.GoalsB)
+                {
+                    AssignWinnerAccumulatedData(result, MatchOutcome.WinA, match.TeamAID, matchProbability.WinA, false,
+                        AdptRatings.AAttackRating, AdptRatings.ADefenseRating);
+                }
+                else if (score.GoalsB > score.GoalsA)
+                {
+                    AssignWinnerAccumulatedData(result, MatchOutcome.WinB, match.TeamBID, matchProbability.WinB, false,
+                        AdptRatings.BAttackRating, AdptRatings.BDefenseRating);
+                }
+                else
+                {
+                    if (winner.MatchOutcome == MatchOutcome.WinA)
+                    {
+                        AssignWinnerAccumulatedData(result, MatchOutcome.WinA, match.TeamAID, winner.AProbability, true,
+                            AdptRatings.AAttackRating, AdptRatings.ADefenseRating);
+                    }
+                    else
+                    {
+                        AssignWinnerAccumulatedData(result, MatchOutcome.WinB, match.TeamBID, winner.BProbability, true,
+                            AdptRatings.BAttackRating, AdptRatings.BDefenseRating);
+                    }
+                }
+                results.Add(result);
+            }
+            return results;
+        }
+
         private MatchProbabilityDTO GetProbabilities(SimpleSimulationMatchDTO match)
         {
             var lambdaA = _matchProbabilityService.CalculateLambda(match.AAttackRating, match.BDefenseRating);
             var lambdaB = _matchProbabilityService.CalculateLambda(match.BAttackRating, match.ADefenseRating);
             return _matchProbabilityService.CalculateMatchProbabilities(MaxGoals, lambdaA, lambdaB);
+        }
+
+        private static void ValidateMatches<T>(List<T> matches)
+        {
+            if (matches == null || matches.Count == 0)
+                throw new ArgumentException("Matches list is empty.");
+        }
+
+        private static KnockoutWinnerDTO PickKnockoutWinner(double winA, double winB)
+        {
+            if (winA == 0 && winB == 0)
+                throw new ArgumentException("Probabilities cannot be 0.");
+
+            double totalProbability = winA + winB;
+            double AProbability = winA / totalProbability;
+            double BProbability = winB / totalProbability;
+
+            double roll = Random.Shared.NextDouble();
+
+            var winner = roll <= AProbability ? MatchOutcome.WinA : MatchOutcome.WinB;
+
+            return new KnockoutWinnerDTO
+            {
+                MatchOutcome = winner,
+                AProbability = AProbability,
+                BProbability = BProbability,
+            };
+        }
+
+        private AdaptativeRatingsDTO CalculateAdaptativeProbabilities(AdaptativeSimulationMatchDTO match,
+                List<RatingDataDTO> aRatingData, List<RatingDataDTO> bRatingData)
+        {
+            var aAttackRating = _ratingService.CalculateAttack(aRatingData, match.AAccumulatedScores,
+                    match.AAccumulatedWeights);
+            var aDefenseRating = _ratingService.CalculateDefense(aRatingData, match.AAccumulatedPenalties,
+                match.AAccumulatedCount);
+            var bAttackRating = _ratingService.CalculateAttack(bRatingData, match.BAccumulatedScores,
+                match.BAccumulatedWeights);
+            var bDefenseRating = _ratingService.CalculateDefense(bRatingData, match.BAccumulatedPenalties,
+                match.BAccumulatedCount);
+
+            var lambdaA = _matchProbabilityService.CalculateLambda(aAttackRating.AttackRating, bDefenseRating.DefenseRating);
+            var lambdaB = _matchProbabilityService.CalculateLambda(bAttackRating.AttackRating, aDefenseRating.DefenseRating);
+
+            return new AdaptativeRatingsDTO
+            {
+                LambdaA = lambdaA,
+                LambdaB = lambdaB,
+                AAttackRating = aAttackRating,
+                ADefenseRating = aDefenseRating,
+                BAttackRating = bAttackRating,
+                BDefenseRating = bDefenseRating
+            };
+        }
+
+        private static void AssignWinnerAccumulatedData(AdaptativeMatchResultDTO result, MatchOutcome winner, int teamID,
+            double probability, bool penalties, AttackRatingDTO attack, DefenseRatingDTO defense)
+        {
+            result.Winner = winner;
+            result.WinnerID = teamID;
+            result.OutcomeProbability = probability;
+            result.DecidedByPenalties = penalties;
+            result.WinnerAccumulatedScores = attack.AccumulatedScores;
+            result.WinnerAccumulatedWeights = attack.AccumulatedWeights;
+            result.WinnerAccumulatedPenalties = defense.AccumulatedPenalties;
+            result.WinnerAccumulatedCount = defense.AccumulatedCount;
         }
 
         private static SimpleMatchResultDTO SimpleBuildResult(SimpleSimulationMatchDTO match, MatchOutcome outcome,
@@ -76,215 +300,8 @@ namespace WCS.Application.Services.Simulators
                 result.WinnerID = match.TeamBID;
                 result.OutcomeProbability = matchProbability.WinB;
             }
-            
+
             return result;
-        }
-
-        public List<SimpleMatchResultDTO> SimpleSimulateGroupsStage (List<SimpleSimulationMatchDTO> matches)
-        {
-            if (matches == null || matches.Count == 0)
-                throw new ArgumentException("Matches list is empty.");
-
-            var results = new List<SimpleMatchResultDTO>();
-
-            foreach (var match in matches)
-            {
-                var matchProbability = GetProbabilities(match);
-                var winner = _matchProbabilityService.PickRandomOutcome(matchProbability);
-                var result = SimpleBuildResult(match, winner, matchProbability);
-
-                results.Add(result);
-            }
-
-            return results;
-        }
-
-        public List<SimpleMatchResultDTO> SimpleSimulateKnockouts(List<SimpleSimulationMatchDTO> matches)
-        {
-            if (matches == null || matches.Count == 0)
-                throw new ArgumentException("Matches list is empty.");
-
-            var results = new List<SimpleMatchResultDTO>();
-
-            foreach (var match in matches)
-            {
-                var matchProbability = GetProbabilities(match);
-
-                double totalProbability = matchProbability.WinA + matchProbability.WinB;
-                double AProbability = matchProbability.WinA / totalProbability;
-
-                double roll = Random.Shared.NextDouble();
-
-                var winner = roll <= AProbability ? MatchOutcome.WinA : MatchOutcome.WinB;
-
-                var result = SimpleBuildResult(match, winner, matchProbability);
-
-                results.Add(result);
-            }
-
-            return results;
-        }
-
-        public List<MatchResultDTO> SimpleSimulateGroupsStageWithScores(List<SimpleSimulationMatchDTO> matches)
-        {
-            if (matches == null || matches.Count == 0)
-                throw new ArgumentException("Matches list is empty.");
-
-            var results = new List<MatchResultDTO>();
-
-            foreach (var match in matches)
-            {
-                var matchProbability = GetProbabilities(match);
-                var score = _matchProbabilityService.PickRandomScore(matchProbability.Scores);
-
-                var result = BuildResult(match, score, matchProbability);
-
-                if (score.GoalsA == score.GoalsB)
-                {
-                    result.Winner = MatchOutcome.Draw;
-                    result.WinnerID = null;
-                    result.OutcomeProbability = matchProbability.Draw;
-                }
-
-                results.Add(result);
-            }
-
-            return results;
-        }
-
-        public List<MatchResultDTO> SimpleSimulateKnockoutsWithScores(List<SimpleSimulationMatchDTO> matches)
-        {
-            if (matches == null || matches.Count == 0)
-                throw new ArgumentException("Matches list is empty.");
-
-            var results = new List<MatchResultDTO>();
-
-            foreach (var match in matches)
-            {
-                var matchProbability = GetProbabilities(match);
-                var score = _matchProbabilityService.PickRandomScore(matchProbability.Scores);
-
-                double totalProbability = matchProbability.WinA + matchProbability.WinB;
-                double AProbability = matchProbability.WinA / totalProbability;
-                double BProbability = matchProbability.WinB / totalProbability;
-
-                double roll = Random.Shared.NextDouble();
-                var winner = roll <= AProbability ? MatchOutcome.WinA : MatchOutcome.WinB;
-
-                var result = BuildResult(match, score, matchProbability);
-
-                if (score.GoalsA == score.GoalsB)                
-                {
-                    result.Winner = winner;
-
-                    if (winner == MatchOutcome.WinA)
-                    {
-                        result.WinnerID = match.TeamAID;
-                        result.OutcomeProbability = AProbability;
-                        result.DecidedByPenalties = true;
-                    } else
-                    {
-                        result.WinnerID = match.TeamBID;
-                        result.OutcomeProbability = BProbability;
-                        result.DecidedByPenalties = true;
-                    }
-                }
-                results.Add(result);
-            }
-            return results;
-        }
-
-        public List<AdaptativeMatchResultDTO> SimulateAdaptativeKnockoutsWithScores(List<AdaptativeSimulationMatchDTO> matches,
-            List<RatingDataDTO> previousResults)
-        {
-            if (matches == null || matches.Count == 0)
-                throw new ArgumentException("Matches list is empty.");
-
-            var results = new List<AdaptativeMatchResultDTO>();            
-
-            foreach (var match in matches)
-            {
-                var result = new AdaptativeMatchResultDTO
-                {
-                    TeamA = match.TeamA,
-                    TeamB = match.TeamB,                    
-                };
-
-                var aAttackRating = _ratingService.CalculateAttack(previousResults, match.AAccumulatedScores,
-                    match.AAccumulatedWeights);
-                var aDefenseRating = _ratingService.CalculateDefense(previousResults, match.AAccumulatedPenalties,
-                    match.AAccumulatedCount);
-                var bAttackRating = _ratingService.CalculateAttack(previousResults, match.BAccumulatedScores,
-                    match.BAccumulatedWeights);
-                var bDefenseRating = _ratingService.CalculateDefense(previousResults, match.BAccumulatedPenalties,
-                    match.BAccumulatedCount);
-
-                var lambdaA = _matchProbabilityService.CalculateLambda(aAttackRating.AttackRating, bDefenseRating.DefenseRating);
-                var lambdaB = _matchProbabilityService.CalculateLambda(bAttackRating.AttackRating, aDefenseRating.DefenseRating);
-                 
-                var matchProbability = _matchProbabilityService.CalculateMatchProbabilities(MaxGoals, lambdaA, lambdaB);
-                var score = _matchProbabilityService.PickRandomScore(matchProbability.Scores);
-
-                result.GoalsA = score.GoalsA;
-                result.GoalsB = score.GoalsB;
-                result.ScoreProbability = score.Probability;
-
-                double totalProbability = matchProbability.WinA + matchProbability.WinB;
-                double AProbability = matchProbability.WinA / totalProbability;
-                double BProbability = matchProbability.WinB / totalProbability;
-
-                double roll = Random.Shared.NextDouble();
-                var winner = roll <= AProbability ? MatchOutcome.WinA : MatchOutcome.WinB;
-
-
-                if (score.GoalsA > score.GoalsB)
-                {
-                    result.Winner = MatchOutcome.WinA;
-                    result.WinnerID = match.TeamAID;
-                    result.OutcomeProbability = matchProbability.WinA;
-                    result.WinnerAccumulatedScores = aAttackRating.AccumulatedScores;
-                    result.WinnerAccumulatedWeights = aAttackRating.AccumulatedWeights;
-                    result.WinnerAccumulatedPenalties = aDefenseRating.AccumulatedPenalties;
-                    result.WinnerAccumulatedCount = aDefenseRating.AccumulatedCount;
-                }
-                else if (score.GoalsB > score.GoalsA)
-                {
-                    result.Winner = MatchOutcome.WinB;
-                    result.WinnerID = match.TeamBID;
-                    result.OutcomeProbability = matchProbability.WinB;
-                    result.WinnerAccumulatedScores = bAttackRating.AccumulatedScores;
-                    result.WinnerAccumulatedWeights = bAttackRating.AccumulatedWeights;
-                    result.WinnerAccumulatedPenalties = bDefenseRating.AccumulatedPenalties;
-                    result.WinnerAccumulatedCount = bDefenseRating.AccumulatedCount;
-                }
-                else 
-                {
-                    result.Winner = winner;
-
-                    if (winner == MatchOutcome.WinA)
-                    {
-                        result.WinnerID = match.TeamAID;
-                        result.OutcomeProbability = AProbability;
-                        result.DecidedByPenalties = true;
-                        result.WinnerAccumulatedScores = aAttackRating.AccumulatedScores;
-                        result.WinnerAccumulatedWeights = aAttackRating.AccumulatedWeights;
-                        result.WinnerAccumulatedPenalties = aDefenseRating.AccumulatedPenalties;
-                        result.WinnerAccumulatedCount = aDefenseRating.AccumulatedCount;
-                    }
-                    else
-                    {
-                        result.WinnerID = match.TeamBID;
-                        result.OutcomeProbability = BProbability;
-                        result.DecidedByPenalties = true;
-                        result.WinnerAccumulatedScores = bAttackRating.AccumulatedScores;
-                        result.WinnerAccumulatedWeights = bAttackRating.AccumulatedWeights;
-                        result.WinnerAccumulatedPenalties = bDefenseRating.AccumulatedPenalties;
-                        result.WinnerAccumulatedCount = bDefenseRating.AccumulatedCount;
-                    }
-                }
-                results.Add(result);
-            }
-            return results;
         }
     }
 }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Simulators/SimulationService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Simulators/SimulationService.cs
@@ -1,0 +1,290 @@
+﻿using WCS.Application.DTO.MatchesDTO;
+using WCS.Application.DTO.ProbabilitiesDTO;
+using WCS.Application.DTO.RatingsDTO;
+using WCS.Application.Services.Probabilities;
+using WCS.Application.Services.Ratings;
+using WCS.Domain.Enums;
+
+namespace WCS.Application.Services.Simulators
+{
+    public class SimulationService(IMatchProbabilityService matchProbabilityService, IRatingService ratingService) : ISimulationService
+    {
+        private readonly IMatchProbabilityService _matchProbabilityService = matchProbabilityService;
+        private readonly IRatingService _ratingService = ratingService;
+
+        public const int MaxGoals = 6;
+
+        private MatchProbabilityDTO GetProbabilities(SimpleSimulationMatchDTO match)
+        {
+            var lambdaA = _matchProbabilityService.CalculateLambda(match.AAttackRating, match.BDefenseRating);
+            var lambdaB = _matchProbabilityService.CalculateLambda(match.BAttackRating, match.ADefenseRating);
+            return _matchProbabilityService.CalculateMatchProbabilities(MaxGoals, lambdaA, lambdaB);
+        }
+
+        private static SimpleMatchResultDTO SimpleBuildResult(SimpleSimulationMatchDTO match, MatchOutcome outcome,
+            MatchProbabilityDTO matchProbability)
+        {
+            var result = new SimpleMatchResultDTO
+            {
+                TeamA = match.TeamA,
+                TeamB = match.TeamB
+            };
+
+            if (outcome == MatchOutcome.WinA)
+            {
+                result.Winner = MatchOutcome.WinA;
+                result.WinnerID = match.TeamAID;
+                result.OutcomeProbability = matchProbability.WinA;
+            }
+            else if (outcome == MatchOutcome.WinB)
+            {
+                result.Winner = MatchOutcome.WinB;
+                result.WinnerID = match.TeamBID;
+                result.OutcomeProbability = matchProbability.WinB;
+            }
+            else
+            {
+                result.Winner = MatchOutcome.Draw;
+                result.WinnerID = null;
+                result.OutcomeProbability = matchProbability.Draw;
+            }
+
+            return result;
+        }
+
+        private static MatchResultDTO BuildResult(SimpleSimulationMatchDTO match, ScoreProbabilityDTO score,
+            MatchProbabilityDTO matchProbability)
+        {
+            var result = new MatchResultDTO
+            {
+                TeamA = match.TeamA,
+                TeamB = match.TeamB,
+                GoalsA = score.GoalsA,
+                GoalsB = score.GoalsB,
+                ScoreProbability = score.Probability,
+            };
+
+            if (score.GoalsA > score.GoalsB)
+            {
+                result.Winner = MatchOutcome.WinA;
+                result.WinnerID = match.TeamAID;
+                result.OutcomeProbability = matchProbability.WinA;
+            }
+            else if (score.GoalsB > score.GoalsA)
+            {
+                result.Winner = MatchOutcome.WinB;
+                result.WinnerID = match.TeamBID;
+                result.OutcomeProbability = matchProbability.WinB;
+            }
+            
+            return result;
+        }
+
+        public List<SimpleMatchResultDTO> SimpleSimulateGroupsStage (List<SimpleSimulationMatchDTO> matches)
+        {
+            if (matches == null || matches.Count == 0)
+                throw new ArgumentException("Matches list is empty.");
+
+            var results = new List<SimpleMatchResultDTO>();
+
+            foreach (var match in matches)
+            {
+                var matchProbability = GetProbabilities(match);
+                var winner = _matchProbabilityService.PickRandomOutcome(matchProbability);
+                var result = SimpleBuildResult(match, winner, matchProbability);
+
+                results.Add(result);
+            }
+
+            return results;
+        }
+
+        public List<SimpleMatchResultDTO> SimpleSimulateKnockouts(List<SimpleSimulationMatchDTO> matches)
+        {
+            if (matches == null || matches.Count == 0)
+                throw new ArgumentException("Matches list is empty.");
+
+            var results = new List<SimpleMatchResultDTO>();
+
+            foreach (var match in matches)
+            {
+                var matchProbability = GetProbabilities(match);
+
+                double totalProbability = matchProbability.WinA + matchProbability.WinB;
+                double AProbability = matchProbability.WinA / totalProbability;
+
+                double roll = Random.Shared.NextDouble();
+
+                var winner = roll <= AProbability ? MatchOutcome.WinA : MatchOutcome.WinB;
+
+                var result = SimpleBuildResult(match, winner, matchProbability);
+
+                results.Add(result);
+            }
+
+            return results;
+        }
+
+        public List<MatchResultDTO> SimpleSimulateGroupsStageWithScores(List<SimpleSimulationMatchDTO> matches)
+        {
+            if (matches == null || matches.Count == 0)
+                throw new ArgumentException("Matches list is empty.");
+
+            var results = new List<MatchResultDTO>();
+
+            foreach (var match in matches)
+            {
+                var matchProbability = GetProbabilities(match);
+                var score = _matchProbabilityService.PickRandomScore(matchProbability.Scores);
+
+                var result = BuildResult(match, score, matchProbability);
+
+                if (score.GoalsA == score.GoalsB)
+                {
+                    result.Winner = MatchOutcome.Draw;
+                    result.WinnerID = null;
+                    result.OutcomeProbability = matchProbability.Draw;
+                }
+
+                results.Add(result);
+            }
+
+            return results;
+        }
+
+        public List<MatchResultDTO> SimpleSimulateKnockoutsWithScores(List<SimpleSimulationMatchDTO> matches)
+        {
+            if (matches == null || matches.Count == 0)
+                throw new ArgumentException("Matches list is empty.");
+
+            var results = new List<MatchResultDTO>();
+
+            foreach (var match in matches)
+            {
+                var matchProbability = GetProbabilities(match);
+                var score = _matchProbabilityService.PickRandomScore(matchProbability.Scores);
+
+                double totalProbability = matchProbability.WinA + matchProbability.WinB;
+                double AProbability = matchProbability.WinA / totalProbability;
+                double BProbability = matchProbability.WinB / totalProbability;
+
+                double roll = Random.Shared.NextDouble();
+                var winner = roll <= AProbability ? MatchOutcome.WinA : MatchOutcome.WinB;
+
+                var result = BuildResult(match, score, matchProbability);
+
+                if (score.GoalsA == score.GoalsB)                
+                {
+                    result.Winner = winner;
+
+                    if (winner == MatchOutcome.WinA)
+                    {
+                        result.WinnerID = match.TeamAID;
+                        result.OutcomeProbability = AProbability;
+                        result.DecidedByPenalties = true;
+                    } else
+                    {
+                        result.WinnerID = match.TeamBID;
+                        result.OutcomeProbability = BProbability;
+                        result.DecidedByPenalties = true;
+                    }
+                }
+                results.Add(result);
+            }
+            return results;
+        }
+
+        public List<AdaptativeMatchResultDTO> SimulateAdaptativeKnockoutsWithScores(List<AdaptativeSimulationMatchDTO> matches,
+            List<RatingDataDTO> previousResults)
+        {
+            if (matches == null || matches.Count == 0)
+                throw new ArgumentException("Matches list is empty.");
+
+            var results = new List<AdaptativeMatchResultDTO>();            
+
+            foreach (var match in matches)
+            {
+                var result = new AdaptativeMatchResultDTO
+                {
+                    TeamA = match.TeamA,
+                    TeamB = match.TeamB,                    
+                };
+
+                var aAttackRating = _ratingService.CalculateAttack(previousResults, match.AAccumulatedScores,
+                    match.AAccumulatedWeights);
+                var aDefenseRating = _ratingService.CalculateDefense(previousResults, match.AAccumulatedPenalties,
+                    match.AAccumulatedCount);
+                var bAttackRating = _ratingService.CalculateAttack(previousResults, match.BAccumulatedScores,
+                    match.BAccumulatedWeights);
+                var bDefenseRating = _ratingService.CalculateDefense(previousResults, match.BAccumulatedPenalties,
+                    match.BAccumulatedCount);
+
+                var lambdaA = _matchProbabilityService.CalculateLambda(aAttackRating.AttackRating, bDefenseRating.DefenseRating);
+                var lambdaB = _matchProbabilityService.CalculateLambda(bAttackRating.AttackRating, aDefenseRating.DefenseRating);
+                 
+                var matchProbability = _matchProbabilityService.CalculateMatchProbabilities(MaxGoals, lambdaA, lambdaB);
+                var score = _matchProbabilityService.PickRandomScore(matchProbability.Scores);
+
+                result.GoalsA = score.GoalsA;
+                result.GoalsB = score.GoalsB;
+                result.ScoreProbability = score.Probability;
+
+                double totalProbability = matchProbability.WinA + matchProbability.WinB;
+                double AProbability = matchProbability.WinA / totalProbability;
+                double BProbability = matchProbability.WinB / totalProbability;
+
+                double roll = Random.Shared.NextDouble();
+                var winner = roll <= AProbability ? MatchOutcome.WinA : MatchOutcome.WinB;
+
+
+                if (score.GoalsA > score.GoalsB)
+                {
+                    result.Winner = MatchOutcome.WinA;
+                    result.WinnerID = match.TeamAID;
+                    result.OutcomeProbability = matchProbability.WinA;
+                    result.WinnerAccumulatedScores = aAttackRating.AccumulatedScores;
+                    result.WinnerAccumulatedWeights = aAttackRating.AccumulatedWeights;
+                    result.WinnerAccumulatedPenalties = aDefenseRating.AccumulatedPenalties;
+                    result.WinnerAccumulatedCount = aDefenseRating.AccumulatedCount;
+                }
+                else if (score.GoalsB > score.GoalsA)
+                {
+                    result.Winner = MatchOutcome.WinB;
+                    result.WinnerID = match.TeamBID;
+                    result.OutcomeProbability = matchProbability.WinB;
+                    result.WinnerAccumulatedScores = bAttackRating.AccumulatedScores;
+                    result.WinnerAccumulatedWeights = bAttackRating.AccumulatedWeights;
+                    result.WinnerAccumulatedPenalties = bDefenseRating.AccumulatedPenalties;
+                    result.WinnerAccumulatedCount = bDefenseRating.AccumulatedCount;
+                }
+                else 
+                {
+                    result.Winner = winner;
+
+                    if (winner == MatchOutcome.WinA)
+                    {
+                        result.WinnerID = match.TeamAID;
+                        result.OutcomeProbability = AProbability;
+                        result.DecidedByPenalties = true;
+                        result.WinnerAccumulatedScores = aAttackRating.AccumulatedScores;
+                        result.WinnerAccumulatedWeights = aAttackRating.AccumulatedWeights;
+                        result.WinnerAccumulatedPenalties = aDefenseRating.AccumulatedPenalties;
+                        result.WinnerAccumulatedCount = aDefenseRating.AccumulatedCount;
+                    }
+                    else
+                    {
+                        result.WinnerID = match.TeamBID;
+                        result.OutcomeProbability = BProbability;
+                        result.DecidedByPenalties = true;
+                        result.WinnerAccumulatedScores = bAttackRating.AccumulatedScores;
+                        result.WinnerAccumulatedWeights = bAttackRating.AccumulatedWeights;
+                        result.WinnerAccumulatedPenalties = bDefenseRating.AccumulatedPenalties;
+                        result.WinnerAccumulatedCount = bDefenseRating.AccumulatedCount;
+                    }
+                }
+                results.Add(result);
+            }
+            return results;
+        }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/WCS.Application.csproj
+++ b/WorldCupSimulatorApp/WCS.Application/WCS.Application.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.15" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\WCS.Domain\WCS.Domain.csproj" />
   </ItemGroup>
 </Project>

--- a/WorldCupSimulatorApp/WCS.Domain/Entities/NationalTeam.cs
+++ b/WorldCupSimulatorApp/WCS.Domain/Entities/NationalTeam.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using WCS.Domain.Enums;
 
 namespace WCS.Domain.Entities
@@ -16,7 +17,6 @@ namespace WCS.Domain.Entities
         public int CurrentFifaRank { get; set; }
         public double AttackRating { get; set; }
         public double DefenseRating { get; set; }
-        public double OverallRating { get; set; }
         public double AvgGoalsScored { get; set; }
         public double AvgGoalsConceded { get; set; }
 
@@ -24,5 +24,8 @@ namespace WCS.Domain.Entities
         public List<HistoricalMatch> TeamBMatches { get; set; } = [];
 
         public WorldCupTeam? WorldCupTeam { get; set; }
+
+        [NotMapped]
+        public double OverallRating => AttackRating * 0.55 + DefenseRating * 0.45;
     }
 }

--- a/WorldCupSimulatorApp/WCS.Domain/Entities/NationalTeam.cs
+++ b/WorldCupSimulatorApp/WCS.Domain/Entities/NationalTeam.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 using WCS.Domain.Enums;
 
 namespace WCS.Domain.Entities
@@ -20,7 +19,7 @@ namespace WCS.Domain.Entities
         public double AccumulatedScores { get; set; }
         public double AccumulatedWeights { get; set; }
         public double AccumulatedPenalties { get; set; }
-        public double AccumulatedCount { get; set; }
+        public int AccumulatedCount { get; set; }
 
         public List<HistoricalMatch> TeamAMatches { get; set; } = [];
         public List<HistoricalMatch> TeamBMatches { get; set; } = [];

--- a/WorldCupSimulatorApp/WCS.Domain/Entities/NationalTeam.cs
+++ b/WorldCupSimulatorApp/WCS.Domain/Entities/NationalTeam.cs
@@ -17,15 +17,14 @@ namespace WCS.Domain.Entities
         public int CurrentFifaRank { get; set; }
         public double AttackRating { get; set; }
         public double DefenseRating { get; set; }
-        public double AvgGoalsScored { get; set; }
-        public double AvgGoalsConceded { get; set; }
+        public double AccumulatedScores { get; set; }
+        public double AccumulatedWeights { get; set; }
+        public double AccumulatedPenalties { get; set; }
+        public double AccumulatedCount { get; set; }
 
         public List<HistoricalMatch> TeamAMatches { get; set; } = [];
         public List<HistoricalMatch> TeamBMatches { get; set; } = [];
 
         public WorldCupTeam? WorldCupTeam { get; set; }
-
-        [NotMapped]
-        public double OverallRating => AttackRating * 0.55 + DefenseRating * 0.45;
     }
 }

--- a/WorldCupSimulatorApp/WCS.Domain/Entities/RatingWeightsOptions.cs
+++ b/WorldCupSimulatorApp/WCS.Domain/Entities/RatingWeightsOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace WCS.Domain.Entities
+{
+    public class RatingWeightsOptions
+    {
+        public Dictionary<string, double> Competition { get; set; } = [];
+        public Dictionary<string, double> Stage { get; set; } = [];
+        public Dictionary<string, double> Confederation { get; set; } = [];
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Domain/Enums/MatchOutcome.cs
+++ b/WorldCupSimulatorApp/WCS.Domain/Enums/MatchOutcome.cs
@@ -1,0 +1,9 @@
+﻿namespace WCS.Domain.Enums
+{
+    public enum MatchOutcome
+    {
+        WinA,
+        Draw,
+        WinB
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Migrations/20260420005056_DeleteOverallRatingField.Designer.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Migrations/20260420005056_DeleteOverallRatingField.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WCS.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using WCS.Infrastructure.Persistence;
 namespace WCS.Infrastructure.Migrations
 {
     [DbContext(typeof(EFCoreDbContext))]
-    partial class EFCoreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260420005056_DeleteOverallRatingField")]
+    partial class DeleteOverallRatingField
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Migrations/20260420005056_DeleteOverallRatingField.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Migrations/20260420005056_DeleteOverallRatingField.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WCS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class DeleteOverallRatingField : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_NationalTeam_OverallRating",
+                table: "NationalTeams");
+
+            migrationBuilder.DropColumn(
+                name: "OverallRating",
+                table: "NationalTeams");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "OverallRating",
+                table: "NationalTeams",
+                type: "double precision",
+                precision: 5,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_NationalTeam_OverallRating",
+                table: "NationalTeams",
+                sql: "\"OverallRating\" >= 0");
+        }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Migrations/20260421234442_AddRatingAccumulators.Designer.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Migrations/20260421234442_AddRatingAccumulators.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WCS.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using WCS.Infrastructure.Persistence;
 namespace WCS.Infrastructure.Migrations
 {
     [DbContext(typeof(EFCoreDbContext))]
-    partial class EFCoreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421234442_AddRatingAccumulators")]
+    partial class AddRatingAccumulators
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Migrations/20260421234442_AddRatingAccumulators.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Migrations/20260421234442_AddRatingAccumulators.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WCS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRatingAccumulators : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_NationalTeam_AvgGoalsConceded",
+                table: "NationalTeams");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_NationalTeam_AvgGoalsScored",
+                table: "NationalTeams");
+
+            migrationBuilder.RenameColumn(
+                name: "AvgGoalsScored",
+                table: "NationalTeams",
+                newName: "AccumulatedWeights");
+
+            migrationBuilder.RenameColumn(
+                name: "AvgGoalsConceded",
+                table: "NationalTeams",
+                newName: "AccumulatedScores");
+
+            migrationBuilder.AddColumn<double>(
+                name: "AccumulatedCount",
+                table: "NationalTeams",
+                type: "double precision",
+                precision: 5,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<double>(
+                name: "AccumulatedPenalties",
+                table: "NationalTeams",
+                type: "double precision",
+                precision: 5,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_NationalTeam_AccumulatedCount",
+                table: "NationalTeams",
+                sql: "\"AccumulatedCount\" >= 0");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_NationalTeam_AccumulatedPenalties",
+                table: "NationalTeams",
+                sql: "\"AccumulatedPenalties\" >= 0");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_NationalTeam_AccumulatedScores",
+                table: "NationalTeams",
+                sql: "\"AccumulatedScores\" >= 0");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_NationalTeam_AccumulatedWeights",
+                table: "NationalTeams",
+                sql: "\"AccumulatedWeights\" >= 0");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_NationalTeam_AccumulatedCount",
+                table: "NationalTeams");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_NationalTeam_AccumulatedPenalties",
+                table: "NationalTeams");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_NationalTeam_AccumulatedScores",
+                table: "NationalTeams");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_NationalTeam_AccumulatedWeights",
+                table: "NationalTeams");
+
+            migrationBuilder.DropColumn(
+                name: "AccumulatedCount",
+                table: "NationalTeams");
+
+            migrationBuilder.DropColumn(
+                name: "AccumulatedPenalties",
+                table: "NationalTeams");
+
+            migrationBuilder.RenameColumn(
+                name: "AccumulatedWeights",
+                table: "NationalTeams",
+                newName: "AvgGoalsScored");
+
+            migrationBuilder.RenameColumn(
+                name: "AccumulatedScores",
+                table: "NationalTeams",
+                newName: "AvgGoalsConceded");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_NationalTeam_AvgGoalsConceded",
+                table: "NationalTeams",
+                sql: "\"AvgGoalsConceded\" >= 0");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_NationalTeam_AvgGoalsScored",
+                table: "NationalTeams",
+                sql: "\"AvgGoalsScored\" >= 0");
+        }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Migrations/20260422234947_ChangeAccumulativeCountToInt.Designer.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Migrations/20260422234947_ChangeAccumulativeCountToInt.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WCS.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using WCS.Infrastructure.Persistence;
 namespace WCS.Infrastructure.Migrations
 {
     [DbContext(typeof(EFCoreDbContext))]
-    partial class EFCoreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422234947_ChangeAccumulativeCountToInt")]
+    partial class ChangeAccumulativeCountToInt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Migrations/20260422234947_ChangeAccumulativeCountToInt.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Migrations/20260422234947_ChangeAccumulativeCountToInt.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WCS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeAccumulativeCountToInt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "AccumulatedCount",
+                table: "NationalTeams",
+                type: "integer",
+                precision: 3,
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision",
+                oldPrecision: 5,
+                oldScale: 2);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<double>(
+                name: "AccumulatedCount",
+                table: "NationalTeams",
+                type: "double precision",
+                precision: 5,
+                scale: 2,
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldPrecision: 3);
+        }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Persistence/EFCoreDbContext.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Persistence/EFCoreDbContext.cs
@@ -57,7 +57,7 @@ namespace WCS.Infrastructure.Persistence
                     .HasPrecision(5, 2);
 
                 entity.Property(x => x.AccumulatedCount)
-                    .HasPrecision(5, 2);
+                    .HasPrecision(3);
 
                 entity.HasMany(t => t.TeamAMatches)
                     .WithOne(hm => hm.TeamA)

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Persistence/EFCoreDbContext.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Persistence/EFCoreDbContext.cs
@@ -47,10 +47,16 @@ namespace WCS.Infrastructure.Persistence
                 entity.Property(x => x.DefenseRating)
                     .HasPrecision(5, 2);
 
-                entity.Property(x => x.AvgGoalsScored)
+                entity.Property(x => x.AccumulatedScores)
                     .HasPrecision(5, 2);
 
-                entity.Property(x => x.AvgGoalsConceded)
+                entity.Property(x => x.AccumulatedWeights)
+                    .HasPrecision(5, 2);
+
+                entity.Property(x => x.AccumulatedPenalties)
+                    .HasPrecision(5, 2);
+
+                entity.Property(x => x.AccumulatedCount)
                     .HasPrecision(5, 2);
 
                 entity.HasMany(t => t.TeamAMatches)
@@ -78,12 +84,20 @@ namespace WCS.Infrastructure.Persistence
                         "\"DefenseRating\" >= 0");
 
                     t.HasCheckConstraint(
-                        "CK_NationalTeam_AvgGoalsScored",
-                        "\"AvgGoalsScored\" >= 0");
+                        "CK_NationalTeam_AccumulatedScores",
+                        "\"AccumulatedScores\" >= 0");
 
                     t.HasCheckConstraint(
-                        "CK_NationalTeam_AvgGoalsConceded",
-                        "\"AvgGoalsConceded\" >= 0");
+                        "CK_NationalTeam_AccumulatedWeights",
+                        "\"AccumulatedWeights\" >= 0");
+
+                    t.HasCheckConstraint(
+                        "CK_NationalTeam_AccumulatedPenalties",
+                        "\"AccumulatedPenalties\" >= 0");
+
+                    t.HasCheckConstraint(
+                        "CK_NationalTeam_AccumulatedCount",
+                        "\"AccumulatedCount\" >= 0");
 
                     t.HasCheckConstraint(
                         "CK_NationalTeam_Code_Length",

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Persistence/EFCoreDbContext.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Persistence/EFCoreDbContext.cs
@@ -47,9 +47,6 @@ namespace WCS.Infrastructure.Persistence
                 entity.Property(x => x.DefenseRating)
                     .HasPrecision(5, 2);
 
-                entity.Property(x => x.OverallRating)
-                    .HasPrecision(5, 2);
-
                 entity.Property(x => x.AvgGoalsScored)
                     .HasPrecision(5, 2);
 
@@ -79,10 +76,6 @@ namespace WCS.Infrastructure.Persistence
                     t.HasCheckConstraint(
                         "CK_NationalTeam_DefenseRating",
                         "\"DefenseRating\" >= 0");
-
-                    t.HasCheckConstraint(
-                        "CK_NationalTeam_OverallRating",
-                        "\"OverallRating\" >= 0");
 
                     t.HasCheckConstraint(
                         "CK_NationalTeam_AvgGoalsScored",


### PR DESCRIPTION
### Summary
Introduces the core probability engine used to evaluate team strength, calculate match result probabilities, and simulate World Cup group stage and knockout matches using historical data and adaptive rating updates.

### Details
Implemented attack and defense rating calculations based on historical match performance
Configured weighting factors for competition type, tournament stage, rankings, and match recency
Created reusable services and DTOs for rating workflows
Implemented scoreline and match outcome probability calculations
Introduced mathematical helper utilities required for probability formulas
Implemented tournament simulations for group stage and knockout matches
Enabled winner-only, score-based, and adaptive simulation modes
Created DTOs for match results, knockout winners, simulation inputs, and rating responses
Updated persistence models and migrations to support accumulated rating data

### Related Issue
Closes #2 