### PR TITLE
merge: feature/15-feat-implement-initial-ratings-calculation-workflow (#16)

### DIFF
--- a/WorldCupSimulatorApp/WCS.Api/Controllers/WorldCupFinalsController.cs
+++ b/WorldCupSimulatorApp/WCS.Api/Controllers/WorldCupFinalsController.cs
@@ -29,7 +29,7 @@ namespace WCS.Api.Controllers
             return Ok(matches);
         }
 
-        [HttpGet]
+        [HttpGet("simulation")]
         [ProducesResponseType(typeof(List<KnockoutMatchDTO>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetAllForSimulation()

--- a/WorldCupSimulatorApp/WCS.Api/Program.cs
+++ b/WorldCupSimulatorApp/WCS.Api/Program.cs
@@ -24,6 +24,7 @@ builder.Services.AddRateLimiter(options =>
 });
 
 builder.Services.AddOpenApi();
+builder.Services.AddSwaggerGen();
 
 builder.Services.AddDbContext<EFCoreDbContext>(options =>
 {
@@ -44,6 +45,7 @@ builder.Services.AddScoped<IWorldCupTeamRepository, WorldCupTeamRepository>();
 builder.Services.AddScoped<IWorldCupFinalsRepository, WorldCupFinalsRepository>();
 builder.Services.AddScoped<IGroupStageService, GroupStageService>();
 builder.Services.AddScoped<IKnockoutsService, KnockoutsService>();
+builder.Services.AddHostedService<InitialRatingsCalculationService>();
 
 var app = builder.Build();
 

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Data/Seeds/InitialRatingsCalculationService.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Data/Seeds/InitialRatingsCalculationService.cs
@@ -1,0 +1,131 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using WCS.Application.DTO.UpdatesDTO;
+using WCS.Application.Services.Ratings;
+using WCS.Infrastructure.Persistence;
+using WCS.Infrastructure.Repositories.Interfaces;
+
+namespace WCS.Infrastructure.Data.Seeds
+{
+    public class InitialRatingsCalculationService : IHostedService
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<InitialRatingsCalculationService> _logger;
+
+        public InitialRatingsCalculationService(IServiceProvider serviceProvider, ILogger<InitialRatingsCalculationService> logger)
+        {
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            using var scope = _serviceProvider.CreateScope();
+
+            var db = scope.ServiceProvider.GetRequiredService<EFCoreDbContext>();
+            var ratingService = scope.ServiceProvider.GetRequiredService<IRatingService>();
+            var matchRepo = scope.ServiceProvider.GetRequiredService<IHistoricalMatchRepository>();
+            var teamRepo = scope.ServiceProvider.GetRequiredService<INationalTeamRepository>();
+
+            // Check if data exists
+            if (!await db.HistoricalMatches.AnyAsync(cancellationToken))
+            {
+                _logger.LogInformation("No historical matches found. Skipping initial ratings calculation.");
+                return;
+            }
+
+            // Check if teams data exists
+            if (!await db.NationalTeams.AnyAsync(cancellationToken))
+            {
+                _logger.LogInformation("No national teams found. Skipping initial ratings calculation.");
+                return;
+            }
+
+            // Check if any team already has calculated attack ratings
+            var hasCalculatedRatings = await db.NationalTeams
+                .AsNoTracking()
+                .AnyAsync(nt => nt.AttackRating > 0, cancellationToken);
+
+            if (hasCalculatedRatings)
+            {
+                _logger.LogInformation("Ratings already calculated. Skipping initial ratings calculation.");
+                return;
+            }
+
+            _logger.LogInformation("Starting initial ratings calculation...");
+
+            // PASS 1: Calculate Attack Ratings
+            _logger.LogInformation("Pass 1: Calculating attack ratings...");
+
+            var ratingData = await matchRepo.GetAllForInitialRatingsAsync();
+            var teamMatches = ratingData.GroupBy(r => r.TeamID);
+            var attackUpdates = new List<NationalTeamStatsUpdateDTO>();
+
+            foreach (var team in teamMatches)
+            {
+                var teamId = team.Key;
+                var matches = team.ToList();
+
+                var attackResult = ratingService.CalculateAttack(matches, 0, 0);
+
+                attackUpdates.Add(new NationalTeamStatsUpdateDTO
+                {
+                    TeamId = teamId,
+                    AttackRating = attackResult.AttackRating,
+                    AccumulatedScores = attackResult.AccumulatedScores,
+                    AccumulatedWeights = attackResult.AccumulatedWeights,
+                    DefenseRating = 0,
+                    AccumulatedPenalties = 0,
+                    AccumulatedCount = 0
+                });
+            }
+
+            await teamRepo.UpdateRatingsStatsBatchAsync(attackUpdates);
+            await teamRepo.SaveAsync();
+            _logger.LogInformation("Attack ratings calculated and saved for {Count} teams.", attackUpdates.Count);
+
+            // PASS 2: Calculate Defense Ratings
+            _logger.LogInformation("Pass 2: Calculating defense ratings...");
+
+            // Reload matches - now with AttackRating populated
+            var ratingDataWithAttack = await matchRepo.GetAllForInitialRatingsAsync();
+            var teamGroupsWithAttack = ratingDataWithAttack.GroupBy(r => r.TeamID);
+            var defenseUpdates = new List<NationalTeamStatsUpdateDTO>();
+
+            foreach (var team in teamGroupsWithAttack)
+            {
+                var teamId = team.Key;
+                var matches = team.ToList();
+
+                var defenseResult = ratingService.CalculateDefense(matches, 0, 0);
+
+                // Get existing attack values from first pass
+                var existingAttack = attackUpdates.First(u => u.TeamId == teamId);
+
+                defenseUpdates.Add(new NationalTeamStatsUpdateDTO
+                {
+                    TeamId = teamId,
+                    AttackRating = existingAttack.AttackRating,
+                    AccumulatedScores = existingAttack.AccumulatedScores,
+                    AccumulatedWeights = existingAttack.AccumulatedWeights,
+                    DefenseRating = defenseResult.DefenseRating,
+                    AccumulatedPenalties = defenseResult.AccumulatedPenalties,
+                    AccumulatedCount = defenseResult.AccumulatedCount
+                });
+            }
+
+            await teamRepo.UpdateRatingsStatsBatchAsync(defenseUpdates);
+            await teamRepo.SaveAsync();
+            _logger.LogInformation("Defense ratings calculated and saved for {Count} teams.", defenseUpdates.Count);
+
+            _logger.LogInformation("Initial ratings calculation completed successfully.");
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Repositories/HistoricalMatchRepository.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Repositories/HistoricalMatchRepository.cs
@@ -34,7 +34,7 @@ namespace WCS.Infrastructure.Repositories
                     GoalsScored = match.GoalsA,
                     GoalsConceded = match.GoalsB,
                     OpponentFifaRank = match.TeamB.CurrentFifaRank,
-                    OpponentAttackRating = 0,
+                    OpponentAttackRating = match.TeamB.AttackRating,
                     Date = match.Date,
                     Competition = match.Competition,
                     Stage = match.Stage
@@ -47,7 +47,7 @@ namespace WCS.Infrastructure.Repositories
                     GoalsScored = match.GoalsB,
                     GoalsConceded = match.GoalsA,
                     OpponentFifaRank = match.TeamA.CurrentFifaRank,
-                    OpponentAttackRating = 0,
+                    OpponentAttackRating = match.TeamA.AttackRating,
                     Date = match.Date,
                     Competition = match.Competition,
                     Stage = match.Stage

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Repositories/WorldCupTeamRepository.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Repositories/WorldCupTeamRepository.cs
@@ -31,7 +31,7 @@ namespace WCS.Infrastructure.Repositories
                 .AsNoTracking()
                 .Include(wt => wt.Team)
                 .Select(wt => new TeamGroupSummaryDTO(
-                    wt.TeamId,
+                    wt.WorldCupTeamId,
                     wt.Team.Name,
                     wt.Team.CurrentFifaRank,
                     wt.GroupCode,


### PR DESCRIPTION
### Summary
Introduces an automated startup workflow that calculates and persists initial team ratings from historical data, ensuring simulations can rely on precomputed ratings and accumulated statistics.

### Details
- Added InitialRatingsCalculationService to calculate and persist team ratings during application startup
- Integrated the ratings initialization workflow into the hosted service pipeline
- Updated historical match queries to use persisted rating values during recalculations
- Corrected World Cup team data retrieval to use tournament-specific team identifiers
- Fixed controller route conflicts affecting knockout stage endpoints
- Reduced the need for runtime rating recalculations by ensuring ratings are initialized ahead of simulations

### Related Issue
Closes #15 