### PR TITLE
merge: feature/19-feat-expose-third-place-bracket-assignment-service-and-api-endpoint (#20)

### DIFF
--- a/WorldCupSimulatorApp/WCS.Api/Controllers/AdminController.cs
+++ b/WorldCupSimulatorApp/WCS.Api/Controllers/AdminController.cs
@@ -13,18 +13,16 @@ namespace WCS.Api.Controllers
     public class AdminController : ControllerBase
     {
         private readonly IConfiguration _configuration;
-        private readonly IHistoricalMatchRepository _historicalMatchRepository;
         private readonly IWorldCupFinalsRepository _worldCupFinalsRepository;
         private readonly IWorldCupMatchRepository _worldCupMatchRepository;
         private readonly INationalTeamRepository _nationalTeamRepository;
         private readonly IWorldCupTeamRepository _worldCupTeamRepository;
 
-        public AdminController(IConfiguration configuration, IHistoricalMatchRepository historicalMatchRepository,
+        public AdminController(IConfiguration configuration,
             IWorldCupFinalsRepository worldCupFinalsRepository, IWorldCupMatchRepository worldCupMatchRepository,
             INationalTeamRepository nationalTeamRepository, IWorldCupTeamRepository worldCupTeamRepository)
         {
             _configuration = configuration;
-            _historicalMatchRepository = historicalMatchRepository;
             _worldCupFinalsRepository = worldCupFinalsRepository;
             _worldCupMatchRepository = worldCupMatchRepository;
             _nationalTeamRepository = nationalTeamRepository;
@@ -35,59 +33,7 @@ namespace WCS.Api.Controllers
         {
             return apiKey == _configuration["AdminApiKey:ApiKey"];
         }
-
-        [HttpPost("historical-matches")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> PostHistoricalMatch(
-            [FromHeader(Name = "API-Key")] string apiKey,
-            [FromBody] List<HistoricalMatchCreateDTO> matches)
-        {
-            if (!IsAuthorized(apiKey))
-                return Unauthorized(new { message = "Invalid API key." });
-
-            if (matches == null || matches.Count == 0)
-                return BadRequest(new { message = "Matches list cannot be empty." });
-
-            // Validate Team Ids
-            var teamIds = matches
-                .SelectMany(m => new[] { m.TeamAId, m.TeamBId })
-                .Distinct()
-                .ToList();
-
-            var existingIds = await _worldCupTeamRepository.GetExistingIdsAsync(teamIds);
-            var invalidIds = teamIds.Except(existingIds);
-
-            if (invalidIds.Any())
-            {
-                return BadRequest(new
-                {
-                    message = $"Invalid team ids: {string.Join(", ", invalidIds)}"
-                });
-            }
-
-            // Validate Goals
-            var invalidGoals = matches.Where(m => m.GoalsA < 0 || m.GoalsB < 0).ToList();
-            if (invalidGoals.Any())
-                return BadRequest(new { message = "Invalid goal counts detected" });
-
-            var entities = matches.Select(dto => new HistoricalMatch
-            {
-                Date = dto.Date,
-                GoalsA = dto.GoalsA,
-                GoalsB = dto.GoalsB,
-                Competition = dto.Competition,
-                Stage = dto.Stage,
-                TeamAId = dto.TeamAId,
-                TeamBId = dto.TeamBId
-            }).ToList();
-
-            await _historicalMatchRepository.InsertListAsync(entities);
-
-            return Ok(new { message = $"{entities.Count} historical matches inserted successfully." });
-        }
-
+                
         [HttpPost("finals-matches")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/WorldCupSimulatorApp/WCS.Api/Controllers/WorldCupMatchesController.cs
+++ b/WorldCupSimulatorApp/WCS.Api/Controllers/WorldCupMatchesController.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using WCS.Application.DTO.BracketsDTO;
 using WCS.Application.DTO.DisplaysDTO;
+using WCS.Application.Services.Brackets;
 using WCS.Infrastructure.Repositories.Interfaces;
 
 namespace WCS.Api.Controllers
@@ -9,10 +11,12 @@ namespace WCS.Api.Controllers
     public class WorldCupMatchesController : ControllerBase
     {
         private readonly IWorldCupMatchRepository _matchRepository;
+        private readonly IBracketThirdPlaceService _thirdPlaceService;
 
-        public WorldCupMatchesController(IWorldCupMatchRepository matchRepository)
+        public WorldCupMatchesController(IWorldCupMatchRepository matchRepository, IBracketThirdPlaceService thirdPlaceService)
         {
             _matchRepository = matchRepository;
+            _thirdPlaceService = thirdPlaceService;
         }
 
         [HttpGet]
@@ -43,6 +47,34 @@ namespace WCS.Api.Controllers
                 return NotFound(new { message = $"No matches found for group {groupCode}." });
 
             return Ok(matches);
+        }
+
+        // Assigns third-place teams to bracket slots.
+        [HttpPost("third-places")]
+        [ProducesResponseType(typeof(List<ThirdPlaceAssignmentDTO>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public IActionResult AssignThirdPlaces([FromBody] List<ThirdPlaceInputDTO> request)
+        {
+            if (request == null || request.Count != 8)
+                return BadRequest(new { message = "Exactly 8 third-place teams required." });
+
+            var invalidIndices = request.Where(r => r.Index < 0 || r.Index > 7).ToList();
+            if (invalidIndices.Any())
+                return BadRequest(new { message = "Indices must be between 0 and 7." });
+
+            var distinctIndices = request.Select(r => r.Index).Distinct().Count();
+            if (distinctIndices != 8)
+                return BadRequest(new { message = "All indices must be unique." });
+
+            try
+            {
+                var assignments = _thirdPlaceService.AssignThirdPlaces(request);
+                return Ok(assignments);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
         }
     }
 }

--- a/WorldCupSimulatorApp/WCS.Api/Program.cs
+++ b/WorldCupSimulatorApp/WCS.Api/Program.cs
@@ -13,6 +13,22 @@ using WCS.Infrastructure.Repositories.Interfaces;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
+builder.Services.AddOpenApi();
+builder.Services.AddSwaggerGen();
+
+var Policy = "AllowFrontend";
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy(name: Policy,
+    policy =>
+    {
+        policy
+            .WithOrigins($"{builder.Configuration["FrontendUrl:Url"]}")
+            .AllowAnyMethod()
+            .AllowAnyHeader();
+    });
+});
 
 builder.Services.AddRateLimiter(options =>
 {
@@ -22,9 +38,6 @@ builder.Services.AddRateLimiter(options =>
         opt.Window = TimeSpan.FromMinutes(1);
     });
 });
-
-builder.Services.AddOpenApi();
-builder.Services.AddSwaggerGen();
 
 builder.Services.AddDbContext<EFCoreDbContext>(options =>
 {
@@ -46,6 +59,7 @@ builder.Services.AddScoped<IWorldCupFinalsRepository, WorldCupFinalsRepository>(
 builder.Services.AddScoped<IGroupStageService, GroupStageService>();
 builder.Services.AddScoped<IKnockoutsService, KnockoutsService>();
 builder.Services.AddHostedService<InitialRatingsCalculationService>();
+builder.Services.AddScoped<IBracketThirdPlaceService, BracketThirdPlaceService>();
 
 var app = builder.Build();
 
@@ -55,6 +69,8 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+app.UseCors(Policy);
 
 app.UseHttpsRedirection();
 

--- a/WorldCupSimulatorApp/WCS.Api/appsettings.json
+++ b/WorldCupSimulatorApp/WCS.Api/appsettings.json
@@ -7,6 +7,10 @@
   },
   "AllowedHosts": "*",
 
+  "FrontendUrl": {
+    "Url": ""
+  },
+
   "ConnectionString": {
     "EFCoreDBConnection": ""
   },

--- a/WorldCupSimulatorApp/WCS.Application/DTO/BracketsDTO/ThirdPlaceAssignmentDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/BracketsDTO/ThirdPlaceAssignmentDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace WCS.Application.DTO.BracketsDTO
+{
+    public class ThirdPlaceAssignmentDTO
+    {
+        public int Key { get; set; }        // Match key: 1, 2, 7, 8, 11, 12, 15, 16
+        public int Index { get; set; }      // 0-7
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/BracketsDTO/ThirdPlaceInputDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/BracketsDTO/ThirdPlaceInputDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace WCS.Application.DTO.BracketsDTO
+{
+    public class ThirdPlaceInputDTO
+    {
+        public int Index { get; set; }      // 0-7 (ranking order from frontend)
+        public string Group { get; set; } = string.Empty;  // "A", "B", etc.
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/DTO/DisplaysDTO/WorldCupMatchDisplayDTO.cs
+++ b/WorldCupSimulatorApp/WCS.Application/DTO/DisplaysDTO/WorldCupMatchDisplayDTO.cs
@@ -13,5 +13,6 @@
         public string? TeamBCode { get; set; }
         public int? GoalsA { get; set; }
         public int? GoalsB { get; set; }
+        public bool Played { get; set; }
     }
 }

--- a/WorldCupSimulatorApp/WCS.Application/Services/Brackets/BracketThirdPlaceService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Brackets/BracketThirdPlaceService.cs
@@ -1,0 +1,113 @@
+﻿using WCS.Application.DTO.BracketsDTO;
+
+namespace WCS.Application.Services.Brackets
+{
+    public class BracketThirdPlaceService : IBracketThirdPlaceService
+    {
+        // Matches with BestThirdSlot in order of their keys
+        // These are the 8 matches where third-place teams can be assigned
+        private static readonly int[] ThirdPlaceMatchKeys = { 1, 2, 7, 8, 11, 12, 15, 16 };
+
+        public List<ThirdPlaceAssignmentDTO> AssignThirdPlaces(List<ThirdPlaceInputDTO> thirdPlaces)
+        {
+            if (thirdPlaces == null || thirdPlaces.Count != 8)
+                throw new ArgumentException("Exactly 8 third-place teams required.", nameof(thirdPlaces));
+
+            if (thirdPlaces.Select(t => t.Index).Distinct().Count() != 8)
+                throw new ArgumentException("Indices must be unique (0-7).", nameof(thirdPlaces));
+
+            // Build lookup: group -> index
+            var groupToIndex = thirdPlaces.ToDictionary(
+                t => t.Group.ToUpperInvariant(),
+                t => t.Index);
+
+            // Get third-place slots from bracket definitions
+            var thirdPlaceSlots = GetThirdPlaceSlots();
+
+            // Run backtracking to find valid assignment
+            var assignments = new Dictionary<int, int>(); // matchKey -> index
+            var availableGroups = new HashSet<string>(groupToIndex.Keys);
+
+            if (!TryAssign(0, thirdPlaceSlots, groupToIndex, availableGroups, assignments))
+            {
+                var groups = string.Join(", ", thirdPlaces.Select(t => t.Group));
+                throw new InvalidOperationException(
+                    $"Unable to assign third-place teams to bracket slots. " +
+                    $"The combination of groups ({groups}) creates an impossible bracket configuration.");
+            }
+
+            // Convert to DTOs
+            return assignments
+                .Select(a => new ThirdPlaceAssignmentDTO
+                {
+                    Key = a.Key,
+                    Index = a.Value
+                })
+                .OrderBy(dto => ThirdPlaceMatchKeys.ToList().IndexOf(dto.Key))
+                .ToList();
+        }
+
+        // Extracts the 8 third-place slots from bracket definitions with their eligibility.
+        private List<ThirdPlaceSlotInfo> GetThirdPlaceSlots()
+        {
+            var slots = new List<ThirdPlaceSlotInfo>();
+
+            foreach (var key in ThirdPlaceMatchKeys)
+            {
+                var slot = BracketDefinitions.RoundOf32.First(s => s.MatchKey == key);
+                var bestThird = slot.HomeTeamSlot as BestThirdSlot
+                    ?? slot.AwayTeamSlot as BestThirdSlot;
+
+                if (bestThird == null)
+                    throw new InvalidOperationException($"Match {key} does not have a BestThirdSlot");
+
+                slots.Add(new ThirdPlaceSlotInfo(key, bestThird.EligibleGroups));
+            }
+
+            return slots;
+        }
+
+        // Backtracking algorithm to assign third-place teams to slots.
+        private bool TryAssign(
+            int slotIndex,
+            List<ThirdPlaceSlotInfo> slots,
+            Dictionary<string, int> groupToIndex,
+            HashSet<string> availableGroups,
+            Dictionary<int, int> assignments)
+        {
+            // Base case: all slots assigned
+            if (slotIndex >= slots.Count)
+                return true;
+
+            var slot = slots[slotIndex];
+
+            // Find eligible groups for this slot (intersection of eligible and available)
+            var candidates = availableGroups
+                .Where(g => slot.EligibleGroups.Contains(g))
+                .ToList();
+
+            foreach (var group in candidates)
+            {
+                // Assign this group to this slot
+                assignments[slot.MatchKey] = groupToIndex[group];
+                availableGroups.Remove(group);
+
+                // Recursively try to assign remaining slots
+                if (TryAssign(slotIndex + 1, slots, groupToIndex, availableGroups, assignments))
+                    return true;
+
+                // Backtrack
+                availableGroups.Add(group);
+                assignments.Remove(slot.MatchKey);
+            }
+
+            return false;
+        }
+
+        // Internal representation of a third-place slot requirement.
+        private record ThirdPlaceSlotInfo(
+            int MatchKey,
+            string[] EligibleGroups
+        );
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Application/Services/Brackets/IBracketThirdPlaceService.cs
+++ b/WorldCupSimulatorApp/WCS.Application/Services/Brackets/IBracketThirdPlaceService.cs
@@ -1,0 +1,10 @@
+﻿using WCS.Application.DTO.BracketsDTO;
+
+namespace WCS.Application.Services.Brackets
+{
+    public interface IBracketThirdPlaceService
+    {
+        // Assigns third-place teams to bracket slots using backtracking.
+        List<ThirdPlaceAssignmentDTO> AssignThirdPlaces(List<ThirdPlaceInputDTO> thirdPlaces);
+    }
+}

--- a/WorldCupSimulatorApp/WCS.Infrastructure/Repositories/WorldCupMatchRepository.cs
+++ b/WorldCupSimulatorApp/WCS.Infrastructure/Repositories/WorldCupMatchRepository.cs
@@ -72,7 +72,8 @@ namespace WCS.Infrastructure.Repositories
                     TeamACode = m.TeamA.Team.Code,
                     TeamBCode = m.TeamB.Team.Code,
                     GoalsA = m.GoalsA,
-                    GoalsB = m.GoalsB
+                    GoalsB = m.GoalsB,
+                    Played = m.Played
                 })
                 .ToListAsync();
         }
@@ -98,7 +99,8 @@ namespace WCS.Infrastructure.Repositories
                     TeamACode = m.TeamA.Team.Code,
                     TeamBCode = m.TeamB.Team.Code,
                     GoalsA = m.GoalsA,
-                    GoalsB = m.GoalsB
+                    GoalsB = m.GoalsB,
+                    Played = m.Played
                 })
                 .ToListAsync();
         }


### PR DESCRIPTION
### Summary
Introduces a dedicated backend service and endpoint for resolving third-place team bracket positions.

### Details
- Added a dedicated service to calculate knockout bracket positions for qualified third-place teams
- Simplified third-place assignment logic to return only the slot information required for bracket generation
- Created request and response DTOs to expose a clear API contract for third-place assignment
- Registered the third-place assignment service in the dependency injection container
- Added AssignThirdPlaces endpoint to WorldCupMatchesController
- Updated WorldCupMatchRepository to expose played status as part of match retrieval operations
- Improved match data availability for frontend tournament workflows
- Removed the obsolete PostHistoricalMatch endpoint from AdminController

### Related Issue
Closes #19 